### PR TITLE
DoorstopError during publish with bad links.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ pylint: .depends-dev
 
 .PHONY: test
 test: .depends-ci
-	$(NOSE) --stop
+	$(NOSE)
 
 .PHONY: tests
 tests: .depends-ci

--- a/doorstop/core/item.py
+++ b/doorstop/core/item.py
@@ -8,7 +8,7 @@ from doorstop import common
 from doorstop.common import DoorstopError, DoorstopWarning, DoorstopInfo
 from doorstop.core.base import BaseValidatable, clear_item_cache
 from doorstop.core.base import auto_load, auto_save, BaseFileObject
-from doorstop.core.types import ID, Text, Level
+from doorstop.core.types import Prefix, ID, Text, Level
 from doorstop import settings
 
 
@@ -365,7 +365,15 @@ class Item(BaseValidatable, BaseFileObject):  # pylint: disable=R0902,R0904
     @property
     def parent_items(self):
         """Get a list of items that this item links to."""
-        return [self.tree.find_item(i) for i in self.links]
+        items = []
+        for identifier in self.links:
+            try:
+                item = self.tree.find_item(identifier)
+            except DoorstopError:
+                item = UnknownItem(identifier)
+                logging.warning(item.exception)
+            items.append(item)
+        return items
 
     @property
     def parent_documents(self):
@@ -374,7 +382,12 @@ class Item(BaseValidatable, BaseFileObject):  # pylint: disable=R0902,R0904
         Note: a document only has one parent.
 
         """
-        return [self.tree.find_document(self.document.prefix)]
+        # TODO: determine if an `UnknownDocument` class is needed
+        try:
+            return [self.tree.find_document(self.document.prefix)]
+        except DoorstopError:
+            logging.warning(Prefix.UNKNOWN_MESSGE.format(self.document.prefix))
+            return []
 
     # actions ################################################################
 
@@ -655,3 +668,37 @@ class Item(BaseValidatable, BaseFileObject):  # pylint: disable=R0902,R0904
         if self.document and self in self.document._items:  # pylint:disable=W0212
             self.document._items.remove(self)  # pylint:disable=W0212
         super().delete(self.path)
+
+
+class UnknownItem(object):
+
+    """Represents an unknown item, which doesn't have a path."""
+
+    UNKNOWN_PATH = '???'  # string to represent an unknown path
+
+    def __init__(self, value, spec=Item):
+        self._id = ID(value)
+        self._spec = dir(spec)  # list of attribute names for warnings
+        msg = ID.UNKNOWN_MESSAGE.format(k='', i=self.id)
+        self.exception = DoorstopError(msg)
+
+    def __str__(self):
+        return Item.__str__(self)
+
+    def __getattr__(self, name):
+        if name in self._spec:
+            logging.debug(self.exception)
+        return self.__getattribute__(name)
+
+    @property
+    def id(self):  # pylint: disable=C0103
+        """Get the item's ID."""
+        return self._id
+
+    prefix = Item.prefix
+    number = Item.number
+
+    @property
+    def relpath(self):
+        """Get the unknown item's relative path string."""
+        return "@{}???".format(os.sep, self.UNKNOWN_PATH)

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -7,7 +7,7 @@ import logging
 import markdown
 
 from doorstop.common import DoorstopError, create_dirname
-from doorstop.core.types import iter_documents, iter_items, is_tree
+from doorstop.core.types import iter_documents, iter_items, is_tree, is_item
 from doorstop import settings
 
 CSS = os.path.join(os.path.dirname(__file__), 'files', 'doorstop.css')
@@ -276,14 +276,15 @@ def _format_ref(item):
 
 def _format_links(items, linkify):
     """Format a list of linked items."""
-    if linkify:
-        links = []
-        for item in items:
-            links.append("[{i}]({p}.html#{i})".format(i=item.id,
-                                                      p=item.document.prefix))
-        return ', '.join(links)
-    else:
-        return ', '.join(str(item.id) for item in items)
+    links = []
+    for item in items:
+        if is_item(item) and linkify:
+            link = "[{i}]({p}.html#{i})".format(i=item.id,
+                                                p=item.document.prefix)
+        else:
+            link = str(item.id)  # assume this is an `UnknownItem`
+        links.append(link)
+    return ', '.join(links)
 
 
 def _format_label_links(label, links, linkify):

--- a/doorstop/core/test/test_all.py
+++ b/doorstop/core/test/test_all.py
@@ -461,8 +461,8 @@ class TestExporter(unittest.TestCase):  # pylint: disable=R0904
         else:  # binary file always changes, only copy when not checking
             move_file(temp, path)
 
-# TODO: uncomment
-# @unittest.skipUnless(os.getenv(ENV) or not CHECK_PUBLISHED_CONTENT, REASON)  # pylint: disable=R0904
+
+@unittest.skipUnless(os.getenv(ENV) or not CHECK_PUBLISHED_CONTENT, REASON)  # pylint: disable=R0904
 class TestPublisher(unittest.TestCase):  # pylint: disable=R0904
 
     """Integration tests for the doorstop.core.publisher module."""  # pylint: disable=C0103

--- a/doorstop/core/test/test_document.py
+++ b/doorstop/core/test/test_document.py
@@ -98,12 +98,12 @@ class TestDocument(unittest.TestCase):  # pylint: disable=R0904
 
     @patch('doorstop.common.VERBOSITY', 2)
     def test_str(self):
-        """Verify documents can be converted to strings."""
+        """Verify a document can be converted to a string."""
         self.assertEqual("REQ", str(self.document))
 
     @patch('doorstop.common.VERBOSITY', 3)
     def test_str_verbose(self):
-        """Verify documents can be converted to strings in verbose mode."""
+        """Verify a document can be converted to a string (verbose)."""
         relpath = os.path.relpath(self.document.path, self.document.root)
         text = "REQ (@{}{})".format(os.sep, relpath)
         self.assertEqual(text, str(self.document))

--- a/doorstop/core/tree.py
+++ b/doorstop/core/tree.py
@@ -242,7 +242,7 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
                 item = document.remove_item(identifier, reorder=reorder)
                 return item
 
-        raise DoorstopError("no matching ID: {}".format(identifier))
+        raise DoorstopError(ID.UNKNOWN_MESSAGE.format(k='', i=identifier))
 
     def link_items(self, cid, pid):
         """Add a new link between two items by IDs.
@@ -337,7 +337,7 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
             logging.debug("could not find document: {}".format(prefix))
             self._document_cache[prefix] = None
 
-        raise DoorstopError("no matching prefix: {}".format(prefix))
+        raise DoorstopError(Prefix.UNKNOWN_MESSGE.format(prefix))
 
     def find_item(self, value, _kind=''):
         """Get an item by its ID.
@@ -372,7 +372,7 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
             logging.debug("could not find item: {}".format(identifier))
             self._item_cache[identifier] = None
 
-        raise DoorstopError("no matching{} ID: {}".format(_kind, identifier))
+        raise DoorstopError(ID.UNKNOWN_MESSAGE.format(k=_kind, i=identifier))
 
     def get_issues(self, document_hook=None, item_hook=None):
         """Yield all the tree's issues.

--- a/doorstop/core/types.py
+++ b/doorstop/core/types.py
@@ -15,6 +15,8 @@ class Prefix(str):  # pylint: disable=R0904
 
     """Unique document prefixes."""
 
+    UNKNOWN_MESSGE = "no document with prefix: {}"
+
     def __new__(cls, value=""):
         if isinstance(value, Prefix):
             return value
@@ -54,6 +56,8 @@ class Prefix(str):  # pylint: disable=R0904
 class ID(object):
 
     """Unique item identifier."""
+
+    UNKNOWN_MESSAGE = "no{k} item with ID: {i}"  # k='parent'|'child'|'', i=ID
 
     def __new__(cls, *values):
         if values and isinstance(values[0], ID):
@@ -538,14 +542,33 @@ class Level(object):
         return Level(self.value)
 
 
+def is_tree(obj):
+    """Determine if the object is a tree-like."""
+    return hasattr(obj, 'documents')
+
+
 def is_document(obj):
-    """Determine if the object is a document."""
+    """Determine if the object is a document-like."""
     return hasattr(obj, 'items')
 
 
-def is_tree(obj):
-    """Determine if the object is a tree."""
-    return hasattr(obj, 'documents')
+def is_item(obj):
+    """Determine if the object is item-like."""
+    return hasattr(obj, 'text')
+
+
+def iter_documents(obj, path, ext):
+    """Get an iterator if documents from a tree or document-like object."""
+    if is_tree(obj):
+        # a tree
+        logging.debug("iterating over tree...")
+        for document in obj.documents:
+            path2 = os.path.join(path, document.prefix + ext)
+            yield document, path2
+    else:
+        # assume a document-like object
+        logging.debug("iterating over document-like object...")
+        yield obj, path
 
 
 def iter_items(obj):
@@ -562,17 +585,3 @@ def iter_items(obj):
         # an item
         logging.debug("iterating over an item (in a container)...")
         return [obj]
-
-
-def iter_documents(obj, path, ext):
-    """Get an iterator if documents from a tree or document-like object."""
-    if is_tree(obj):
-        # a tree
-        logging.debug("iterating over tree...")
-        for document in obj.documents:
-            path2 = os.path.join(path, document.prefix + ext)
-            yield document, path2
-    else:
-        # assume a document-like object
-        logging.debug("iterating over document-like object...")
-        yield obj, path


### PR DESCRIPTION
If an item contains links to unknown items, this raises an uncaught exception during publishing:

``` bash
$ doorstop publish all specs-gen/html
publishing tree to specs-gen/html...
Traceback (most recent call last):
  File "/Library/Frameworks/Python.framework/Versions/3.3/bin/doorstop", line 9, in <module>
    load_entry_point('Doorstop==0.7-dev', 'console_scripts', 'doorstop')()
  File "/Users/Browning/Drive/Programs/Desktop/Doorstop/doorstop/cli/main.py", line 177, in main
    success = function(args, os.getcwd(), parser.error)
  File "/Users/Browning/Drive/Programs/Desktop/Doorstop/doorstop/cli/main.py", line 534, in _run_publish
    path = publisher.publish(tree, args.path, ext, **kwargs)
  File "/Users/Browning/Drive/Programs/Desktop/Doorstop/doorstop/core/publisher.py", line 51, in publish
    for line in publish_lines(obj2, ext, linkify=linkify, **kwargs):
  File "/Users/Browning/Drive/Programs/Desktop/Doorstop/doorstop/core/publisher.py", line 123, in publish_lines
    yield from gen(obj, **kwargs)
  File "/Users/Browning/Drive/Programs/Desktop/Doorstop/doorstop/core/publisher.py", line 325, in _lines_html
    text = '\n'.join(_lines_markdown(obj, linkify=linkify))
  File "/Users/Browning/Drive/Programs/Desktop/Doorstop/doorstop/core/publisher.py", line 232, in _lines_markdown
    items2 = item.parent_items
  File "/Users/Browning/Drive/Programs/Desktop/Doorstop/doorstop/core/item.py", line 368, in parent_items
    return [self.tree.find_item(i) for i in self.links]
  File "/Users/Browning/Drive/Programs/Desktop/Doorstop/doorstop/core/item.py", line 368, in <listcomp>
    return [self.tree.find_item(i) for i in self.links]
  File "/Users/Browning/Drive/Programs/Desktop/Doorstop/doorstop/core/tree.py", line 375, in find_item
    raise DoorstopError("no matching{} ID: {}".format(_kind, identifier))
doorstop.common.DoorstopError: no matching ID: Derived
```

The publish function shouldn't raise an exception here, but what should it do:
- not publish the bad link?
- publish the bad link but leave it non-hyperlinked?

Either way, this will require updates to the `Item` properties that call `Tree.find_item()` and `Tree.find_document()`. Maybe these properties shouldn't raise exceptions either?
