### PR TITLE
Use linked CSS.

### DIFF
--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -65,6 +65,13 @@ def publish(obj, path, ext=None, linkify=None, index=None, **kwargs):
         logging.warning("nothing to publish")
         return None
 
+    """ copy the CSS file to the output directory 
+        so we can reference it instead of embedding it
+    """
+    if ext == '.html':
+        shutil.copy(CSS, path)
+
+
 
 def _index(directory, extensions=('.html',)):
     """Create an HTML index of all files in a directory.
@@ -92,21 +99,11 @@ def _index(directory, extensions=('.html',)):
 
 def _lines_index(filenames):
     """Yield lines of HTML for index.html."""
-    yield '<!DOCTYPE html>'
-    yield '<head>'
-    yield '<style type="text/css">'
-    yield ''
-    with open(CSS) as infile:
-        for line in infile:
-            yield line
-    yield '</style>'
-    yield '</head>'
-    yield '<body>'
+    yield header_html()
     for filename in filenames:
         name = os.path.splitext(filename)[0]
         yield '<li> <a href="{f}">{n}</a> </li>'.format(f=filename, n=name)
-    yield '</body>'
-    yield '</html>'
+    yield footer_html()
 
 
 def publish_lines(obj, ext='.txt', **kwargs):


### PR DESCRIPTION
Not sure if there was a reason for the practice of embedding CSS in every HTML page, but I thought I'd try my hand at a little python and link it rather than embedding. Made a few mods to copy the CSS file to the output folder and then create a standard header (and footer) that has the CSS linked. 

This will definitely break if the HTML files are placed into directories, but at this point it appears to be a flat structure. If there are plans to create sub-folders for the HTML output please do let me know.

Not sure this is of interest to anyone else but I thought it was worthwhile to give it a try. And the upside is I'm learning python in the process. Hope I'm not embarrassing myself with my amateur code. Please let me know if you think this is something that's useful. Or, am I breaking something that you intended with the embedding practice?
