### PR TITLE
Remove levels from non-heading items on publish.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ Changelog
 - Added `Item.review()` to save stamps (hashes) of reviewed items.
 - Added `doorstop reorder ...` to organize a document's structure.
 - Renamed `Item.id` and `identifer` arguments to `uid`
+- Added '--no-body-levels' to `doorstop publish` to hide levels on non-headings.
 
 0.7 (2014/07/08)
 ----------------

--- a/doorstop/cli/main.py
+++ b/doorstop/cli/main.py
@@ -279,7 +279,9 @@ def _publish(subs, shared):
     sub.add_argument('-w', '--width', type=int,
                      help="limit line width on text output")
     sub.add_argument('-C', '--no-child-links', action='store_true',
-                     help="do not include child links in published documents")
+                     help="do not include child links on items")
+    sub.add_argument('-L', '--no-body-levels', action='store_true',
+                     help="do not include levels on non-heading items")
 
 
 if __name__ == '__main__':  # pragma: no cover (manual test)

--- a/doorstop/cli/test/__init__.py
+++ b/doorstop/cli/test/__init__.py
@@ -27,7 +27,8 @@ class SettingsTestCase(unittest.TestCase):
                        settings.CHECK_LEVELS,
                        settings.PUBLISH_CHILD_LINKS,
                        settings.CHECK_SUSPECT_LINKS,
-                       settings.CHECK_REVIEW_STATUS)
+                       settings.CHECK_REVIEW_STATUS,
+                       settings.PUBLISH_BODY_LEVELS)
 
     def tearDown(self):
         (settings.REFORMAT,
@@ -37,4 +38,5 @@ class SettingsTestCase(unittest.TestCase):
          settings.CHECK_LEVELS,
          settings.PUBLISH_CHILD_LINKS,
          settings.CHECK_SUSPECT_LINKS,
-         settings.CHECK_REVIEW_STATUS) = self.backup
+         settings.CHECK_REVIEW_STATUS,
+         settings.PUBLISH_BODY_LEVELS) = self.backup

--- a/doorstop/cli/test/test_all.py
+++ b/doorstop/cli/test/test_all.py
@@ -645,11 +645,13 @@ class TestPublish(TempTestCase):
 
     def setUp(self):
         super().setUp()
-        self.backup = (settings.PUBLISH_CHILD_LINKS,)
+        self.backup = (settings.PUBLISH_CHILD_LINKS,
+                       settings.PUBLISH_BODY_LEVELS)
 
     def tearDown(self):
         super().tearDown()
-        (settings.PUBLISH_CHILD_LINKS,) = self.backup
+        (settings.PUBLISH_CHILD_LINKS,
+         settings.PUBLISH_BODY_LEVELS) = self.backup
 
     def test_publish_unknown(self):
         """Verify 'doorstop publish' returns an error for an unknown format."""
@@ -669,6 +671,11 @@ class TestPublish(TempTestCase):
         """Verify 'doorstop publish' can create output without child links."""
         self.assertIs(None, main(['publish', 'tut', '--no-child-links']))
         self.assertFalse(settings.PUBLISH_CHILD_LINKS)
+
+    def test_publish_document_without_body_levels(self):
+        """Verify 'doorstop publish' can create output without body levels."""
+        self.assertIs(None, main(['publish', 'tut', '--no-body-levels']))
+        self.assertFalse(settings.PUBLISH_BODY_LEVELS)
 
     def test_publish_document_error_empty(self):
         """Verify 'doorstop publish' returns an error in an empty folder."""

--- a/doorstop/cli/test/test_utilities.py
+++ b/doorstop/cli/test/test_utilities.py
@@ -55,6 +55,7 @@ class TestConfigureSettings(SettingsTestCase):
         self.assertFalse(settings.PUBLISH_CHILD_LINKS)
         self.assertFalse(settings.CHECK_SUSPECT_LINKS)
         self.assertFalse(settings.CHECK_REVIEW_STATUS)
+        self.assertFalse(settings.PUBLISH_BODY_LEVELS)
 
 
 class TestLiteralEval(unittest.TestCase):

--- a/doorstop/cli/utilities.py
+++ b/doorstop/cli/utilities.py
@@ -97,6 +97,8 @@ def configure_settings(args):
     # Parse subcommand settings
     if hasattr(args, 'no_child_links') and args.no_child_links is not None:
         settings.PUBLISH_CHILD_LINKS = not args.no_child_links
+    if hasattr(args, 'no_body_levels') and args.no_body_levels is not None:
+        settings.PUBLISH_BODY_LEVELS = not args.no_body_levels
 
 
 def literal_eval(literal, err=None, default=None):

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -280,7 +280,10 @@ def _lines_markdown(obj, linkify=False):
         else:
 
             # Level and UID
-            standard = "{h} {l} {u}".format(h=heading, l=level, u=item.uid)
+            if settings.PUBLISH_BODY_LEVELS:
+                standard = "{h} {l} {u}".format(h=heading, l=level, u=item.uid)
+            else:
+                standard = "{h} {u}".format(h=heading, u=item.uid)
             attr_list = _format_md_attr_list(item, linkify)
             yield standard + attr_list
 

--- a/doorstop/core/test/test_publisher.py
+++ b/doorstop/core/test/test_publisher.py
@@ -188,6 +188,19 @@ class TestModule(MockDataMixIn, unittest.TestCase):
         # Assert
         self.assertEqual(expected, text)
 
+    @patch('doorstop.settings.PUBLISH_CHILD_LINKS', False)
+    def test_lines_markdown_item_normative(self):
+        """Verify Markdown can be published from an item (normative)."""
+        expected = ("## 1.2 req4" + '\n\n'
+                    "This shall..." + '\n\n'
+                    "Reference: Doorstop.sublime-project (line None)" + '\n\n'
+                    "*Links: sys4*" + '\n\n')
+        # Act
+        lines = publisher.publish_lines(self.item3, '.md', linkify=False)
+        text = ''.join(line + '\n' for line in lines)
+        # Assert
+        self.assertEqual(expected, text)
+
     @patch('doorstop.settings.PUBLISH_CHILD_LINKS', True)
     def test_lines_markdown_item_with_child_links(self):
         """Verify Markdown can be published from an item w/ child links."""
@@ -206,10 +219,11 @@ class TestModule(MockDataMixIn, unittest.TestCase):
         # Assert
         self.assertNotIn("Child links", text)
 
+    @patch('doorstop.settings.PUBLISH_BODY_LEVELS', False)
     @patch('doorstop.settings.PUBLISH_CHILD_LINKS', False)
-    def test_lines_markdown_item_normative(self):
-        """Verify Markdown can be published from an item (normative)."""
-        expected = ("## 1.2 req4" + '\n\n'
+    def test_lines_markdown_item_without_body_levels(self):
+        """Verify Markdown can be published from an item (no body levels)."""
+        expected = ("## req4" + '\n\n'
                     "This shall..." + '\n\n'
                     "Reference: Doorstop.sublime-project (line None)" + '\n\n'
                     "*Links: sys4*" + '\n\n')

--- a/doorstop/settings.py
+++ b/doorstop/settings.py
@@ -32,6 +32,7 @@ CHECK_REVIEW_STATUS = True  # check stamps on items
 
 # Publishing settings
 PUBLISH_CHILD_LINKS = True  # include child links when publishing
+PUBLISH_BODY_LEVELS = True  # include levels on non-header items
 
 # Caching settings
 CACHE_ITEMS = True


### PR DESCRIPTION
It seems the "level" is unnecessary for requirements that already have an ID. Also it makes the html visually confusing. Maybe this could be an option.

---

TODO:
- [x] add an option to disable body levels
- [x] ~~apply the same behavior when publishing text~~ (text looks fine the way it is)
