### PR TITLE
Add configuration using files and environment variables.

### DIFF
--- a/doorstop/cli/main.py
+++ b/doorstop/cli/main.py
@@ -6,6 +6,8 @@ import os
 import sys
 import argparse
 
+import configman
+
 from doorstop import common
 from doorstop.cli import utilities, commands
 
@@ -17,7 +19,7 @@ def main(args=None):  # pylint: disable=R0915
     from doorstop import CLI, VERSION, DESCRIPTION
 
     # Shared options
-    project = argparse.ArgumentParser(add_help=False)
+    project = configman.ArgumentParser(add_help=False)
     project.add_argument('-j', '--project', metavar='PATH',
                          help="path to the root of the project")
     project.add_argument('--no-cache', action='store_true',

--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,6 @@ setuptools.setup(
         "bottle >= 0.12, < 0.13",
         "requests >= 2, < 3",
         "pyficache >= 0.2.3, < 0.3",
+        "configman >= 1.2.6, < 2",
     ],
 )


### PR DESCRIPTION
Doorstop should accept settings in three different ways:
- command-line options (current)
- configuration file
- environment variables

[configman](https://github.com/mozilla/configman) purports to do [exactly this](http://pyvideo.org/video/2846/configman-the-grand-unified-theorem-of-configur) and can [apparently](http://www.twobraids.com/2014/05/crouching-argparse-hidden-configman.html) work with `argparse`.

---

TODO:
- [ ] research using `configman`
- [ ] determine the order of precedence for configuration options
- [ ] determine which configuration filenames will be accepted
- [ ] implement feature 
  - [ ] support server settings from #117
