### PR TITLE
Copy Markdown linked files when publishing.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,7 +173,7 @@ pep8: .depends-ci
 
 .PHONY: pep257
 pep257: .depends-ci
-	$(PEP257) $(PACKAGE) --ignore=E501,D102
+	$(PEP257) $(PACKAGE) --ignore=D102
 
 .PHONY: pylint
 pylint: .depends-dev

--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -22,6 +22,7 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
 
     CONFIG = '.doorstop.yml'
     SKIP = '.doorstop.skip'  # indicates this document should be skipped
+    ASSETS = 'assets'
     INDEX = 'index.yml'
 
     DEFAULT_PREFIX = Prefix('REQ')
@@ -210,6 +211,13 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         return os.path.join(self.path, Document.CONFIG)
 
     @property
+    def assets(self):
+        """Get the path to the document's assets if they exist else `None`."""
+        path = os.path.join(self.path, Document.ASSETS)
+        if os.path.isdir(path):
+            return path
+
+    @property
     @auto_load
     def prefix(self):
         """Get the document's prefix."""
@@ -306,7 +314,7 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
     def index(self):
         """Get the path to the document's index if it exists else `None`."""
         path = os.path.join(self.path, Document.INDEX)
-        if os.path.exists(path):
+        if os.path.isfile(path):
             return path
 
     @index.setter

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -53,6 +53,8 @@ def publish(obj, path, ext=None, linkify=None, index=None, **kwargs):
         log.info("publishing to {}...".format(path2))
         lines = publish_lines(obj2, ext, linkify=linkify, **kwargs)
         common.write_lines(lines, path2)
+        if obj2.assets:
+            common.copy(obj2.assets, os.path.join(path2, obj2.ASSETS))
 
     # Create index
     if index and count:

--- a/doorstop/core/test/__init__.py
+++ b/doorstop/core/test/__init__.py
@@ -109,6 +109,7 @@ class MockDataMixIn:  # pylint: disable=W0232,R0903
     mock_document = MagicMock()
     mock_document.prefix = 'MOCK'
     mock_document.items = []
+    mock_document.assets = None
     mock_tree = MagicMock()
     mock_tree.documents = [mock_document]
 
@@ -150,6 +151,7 @@ class MockDataMixIn:  # pylint: disable=W0232,R0903
                        _file="links: [sys1]\ntext: 'Heading 2'\nlevel: 2.1.0\n"
                        "normative: false"),
     ]
+    document.assets = None
 
     item3 = MockItem('path/to/req4.yml', _file=(
         "links: [sys4]" + '\n'

--- a/doorstop/core/test/test_document.py
+++ b/doorstop/core/test/test_document.py
@@ -224,7 +224,7 @@ class TestDocument(unittest.TestCase):
     def test_index_get(self):
         """Verify a document's index can be retrieved."""
         self.assertIs(None, self.document.index)
-        with patch('os.path.exists', Mock(return_value=True)):
+        with patch('os.path.isfile', Mock(return_value=True)):
             path = os.path.join(self.document.path, self.document.INDEX)
             self.assertEqual(path, self.document.index)
 


### PR DESCRIPTION
During `doorstop publish all <dir>`:
- create `<dir>/assets/`
- copy references files to relative paths within `<dir>/assets/`
- change Markdown paths to be rooted at `<dir>/assets/`
- publish Markdown

---

TODO:
- [ ] require all assets to be in `<document directory>/assets/`?
