### PR TITLE
For publish cmd, add --no-assets args so that it is possible to exclude copying default doorstop /core/files/assets directory.

### DIFF
--- a/doorstop/cli/commands.py
+++ b/doorstop/cli/commands.py
@@ -498,6 +498,9 @@ def run_publish(args, cwd, error, catch=True):
     if args.width:
         kwargs['width'] = args.width
 
+    if args.no_assets:
+        kwargs['no_assets'] = args.no_assets
+
     # Write to output file(s)
     if args.path:
         path = os.path.abspath(os.path.join(cwd, args.path))

--- a/doorstop/cli/main.py
+++ b/doorstop/cli/main.py
@@ -330,6 +330,7 @@ def _publish(subs, shared):
     sub.add_argument('--no-levels', choices=['all', 'body'],
                      help="do not include levels on heading and non-heading or non-heading items")
     sub.add_argument('--template', help="template file", default=publisher.HTMLTEMPLATE)
+    sub.add_argument('--no-assets', action='store_true', help="do not copy default doorstop assets. This can be useful to customize your own assets.", default=publisher.DO_NOT_COPY_ASSETS)
 
 
 if __name__ == '__main__':  # pragma: no cover (manual test)

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -21,6 +21,7 @@ EXTENSIONS = (
 )
 CSS = os.path.join(os.path.dirname(__file__), 'files', 'doorstop.css')
 HTMLTEMPLATE = 'sidebar'
+DO_NOT_COPY_ASSETS = False
 INDEX = 'index.html'
 
 log = common.logger(__name__)
@@ -59,19 +60,23 @@ def publish(obj, path, ext=None, linkify=None, index=None,
     else:
         assets_dir = os.path.join(os.path.dirname(path), Document.ASSETS)  # path is a filename
 
-    if os.path.isdir(assets_dir):
-        log.info('Deleting contents of assets directory %s', assets_dir)
-        common.delete_contents(assets_dir)
-    else:
-        os.makedirs(assets_dir)
 
-    # If publish html and then markdown ensure that the html template are still available
-    if not template:
-        template = HTMLTEMPLATE
-    template_assets = os.path.join(os.path.dirname(__file__), 'files', 'assets')
-    if os.path.isdir(template_assets):
-        log.info("Copying %s to %s", template_assets, assets_dir)
-        common.copy_dir_contents(template_assets, assets_dir)
+    if not kwargs.get("no_assets", DO_NOT_COPY_ASSETS):
+        if os.path.isdir(assets_dir):
+            log.info('Deleting contents of assets directory %s', assets_dir)
+            common.delete_contents(assets_dir)
+        else:
+            os.makedirs(assets_dir)
+
+        # If publish html and then markdown ensure that the html template are still available
+        if not template:
+            template = HTMLTEMPLATE
+        template_assets = os.path.join(os.path.dirname(__file__), 'files', 'assets')
+        if os.path.isdir(template_assets):
+            log.info("Copying %s to %s", template_assets, assets_dir)
+            common.copy_dir_contents(template_assets, assets_dir)
+
+    kwargs.pop('no_assets', None)
 
     # Publish documents
     count = 0

--- a/doorstop/core/publisher.py
+++ b/doorstop/core/publisher.py
@@ -60,7 +60,6 @@ def publish(obj, path, ext=None, linkify=None, index=None,
     else:
         assets_dir = os.path.join(os.path.dirname(path), Document.ASSETS)  # path is a filename
 
-
     if not kwargs.get("no_assets", DO_NOT_COPY_ASSETS):
         if os.path.isdir(assets_dir):
             log.info('Deleting contents of assets directory %s', assets_dir)
@@ -68,13 +67,13 @@ def publish(obj, path, ext=None, linkify=None, index=None,
         else:
             os.makedirs(assets_dir)
 
-        # If publish html and then markdown ensure that the html template are still available
-        if not template:
-            template = HTMLTEMPLATE
-        template_assets = os.path.join(os.path.dirname(__file__), 'files', 'assets')
-        if os.path.isdir(template_assets):
-            log.info("Copying %s to %s", template_assets, assets_dir)
-            common.copy_dir_contents(template_assets, assets_dir)
+    # If publish html and then markdown ensure that the html template are still available
+    if not template:
+        template = HTMLTEMPLATE
+    template_assets = os.path.join(os.path.dirname(__file__), 'files', 'assets')
+    if os.path.isdir(template_assets) and not kwargs.get("no_assets", DO_NOT_COPY_ASSETS):
+        log.info("Copying %s to %s", template_assets, assets_dir)
+        common.copy_dir_contents(template_assets, assets_dir)
 
     kwargs.pop('no_assets', None)
 


### PR DESCRIPTION
This is useful to be able to customize assets directory.