### PR TITLE
doorstop/cli: fix flaky test_all test not removing temp artifacts

### DIFF
--- a/doorstop/cli/tests/__init__.py
+++ b/doorstop/cli/tests/__init__.py
@@ -8,6 +8,7 @@ import unittest
 from doorstop import settings
 from doorstop.cli.main import main
 
+CLI_TESTS_DIR = os.path.dirname(__file__)
 ROOT = os.path.join(os.path.dirname(__file__), '..', '..', '..')
 REQS = os.path.join(ROOT, 'reqs')
 TUTORIAL = os.path.join(REQS, 'tutorial')

--- a/doorstop/cli/tests/test_all.py
+++ b/doorstop/cli/tests/test_all.py
@@ -15,6 +15,7 @@ from doorstop.cli.tests import (
     FILES,
     REASON,
     REQS,
+    CLI_TESTS_DIR,
     ROOT,
     TUTORIAL,
     SettingsTestCase,
@@ -500,7 +501,7 @@ class TestImport(unittest.TestCase):
     """Integration tests for the 'doorstop import' command."""
 
     def tearDown(self):
-        common.delete(os.path.join(ROOT, 'tmp'))
+        common.delete(os.path.join(CLI_TESTS_DIR, 'tmp'))
         common.delete(os.path.join(REQS, 'REQ099.yml'))
 
     def test_import_document(self):


### PR DESCRIPTION
```python
class TestImport(unittest.TestCase):
    """Integration tests for the 'doorstop import' command."""

    def tearDown(self):
        common.delete(os.path.join(os.getcwd(), 'tmp')) # broken
        common.delete(os.path.join(REQS, 'REQ099.yml'))
```

the first line was not deleting the right path: after running
`test_import_document_with_parent` test the first time I see this git status:

```
Untracked files:
       doorstop/cli/tests/tmp/
```

The solution is simple: use **current directory** as a base, not `ROOT`.