### PR TITLE
ItemValidator class to encapsulate validations of Item

### DIFF
--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -23,6 +23,7 @@ from doorstop.core.base import (
 )
 from doorstop.core.item import Item
 from doorstop.core.types import UID, Level, Prefix
+from doorstop.core.validators.item_validator import ItemValidator
 
 log = common.logger(__name__)
 
@@ -753,13 +754,15 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         elif settings.CHECK_LEVELS:
             yield from self._get_issues_level(items)
 
+        item_validator = ItemValidator()
+
         # Check each item
         for item in items:
 
             # Check item
             for issue in chain(
                 hook(item=item, document=self, tree=self.tree),
-                item.get_issues(skip=skip),
+                item_validator.get_issues(item, skip=skip),
             ):
 
                 # Prepend the item's UID to yielded exceptions

--- a/doorstop/core/tests/__init__.py
+++ b/doorstop/core/tests/__init__.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, Mock, patch
 from doorstop.core.base import BaseFileObject
 from doorstop.core.document import Document
 from doorstop.core.item import Item
+from doorstop.core.validators.item_validator import ItemValidator
 from doorstop.core.vcs.mockvcs import WorkingCopy
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', '..'))
@@ -68,7 +69,13 @@ class MockFileObject(BaseFileObject):  # pylint: disable=W0223,R0902
 class MockItem(MockFileObject, Item):  # pylint: disable=W0223,R0902
     """Mock Item class with stubbed file IO."""
 
-    def _no_get_issues_document(self, document, skip):  # pylint: disable=W0613,R0201
+
+class MockItemValidator(ItemValidator):  # pylint: disable=W0223,R0902
+    """Mock Item class with stubbed file IO."""
+
+    def _no_get_issues_document(
+        self, item, document, skip
+    ):  # pylint: disable=W0613,R0201
         return
         yield  # pylint: disable=W0101
 

--- a/doorstop/core/tests/test_document.py
+++ b/doorstop/core/tests/test_document.py
@@ -651,7 +651,7 @@ outline:
         """Verify an exception is raised on an unknown UID."""
         self.assertRaises(DoorstopError, self.document.find_item, 'unknown99')
 
-    @patch('doorstop.core.item.Item.get_issues')
+    @patch('doorstop.core.validators.item_validator.ItemValidator.get_issues')
     @patch('doorstop.core.document.Document.reorder')
     def test_validate(self, mock_reorder, mock_get_issues):
         """Verify a document can be validated."""
@@ -662,7 +662,7 @@ outline:
         self.assertEqual(5, mock_get_issues.call_count)
 
     @patch(
-        'doorstop.core.item.Item.get_issues',
+        'doorstop.core.validators.item_validator.ItemValidator.get_issues',
         Mock(
             return_value=[
                 DoorstopError('error'),
@@ -675,7 +675,10 @@ outline:
         """Verify an item error fails the document check."""
         self.assertFalse(self.document.validate())
 
-    @patch('doorstop.core.item.Item.get_issues', Mock(return_value=[]))
+    @patch(
+        'doorstop.core.validators.item_validator.ItemValidator.get_issues',
+        Mock(return_value=[]),
+    )
     def test_validate_hook(self):
         """Verify an item hook can be called."""
         mock_hook = MagicMock()

--- a/doorstop/core/tests/test_item.py
+++ b/doorstop/core/tests/test_item.py
@@ -669,217 +669,6 @@ class TestItem(unittest.TestCase):
             DoorstopError, Item.new, None, None, FILES, FILES, 'REQ002', level=(1, 2, 3)
         )
 
-    def test_validate_invalid_ref(self):
-        """Verify an invalid reference fails validity."""
-        with patch(
-            'doorstop.core.item.Item.find_ref',
-            Mock(side_effect=DoorstopError("test invalid ref")),
-        ):
-            with ListLogHandler(core.base.log) as handler:
-                self.assertFalse(self.item.validate())
-                self.assertIn("test invalid ref", handler.records)
-
-    def test_validate_inactive(self):
-        """Verify an inactive item is not checked."""
-        self.item.active = False
-        with patch('doorstop.core.item.Item.find_ref', Mock(side_effect=DoorstopError)):
-            self.assertTrue(self.item.validate())
-
-    def test_validate_reviewed(self):
-        """Verify that checking a reviewed item updates the stamp."""
-        self.item._data['reviewed'] = True
-        self.assertTrue(self.item.validate())
-        stamp = 'c6a87755b8756b61731c704c6a7be4a2'
-        self.assertEqual(stamp, self.item._data['reviewed'])
-
-    @patch('doorstop.settings.REVIEW_NEW_ITEMS', False)
-    def test_validate_reviewed_first(self):
-        """Verify that a missing initial review leaves the stamp empty."""
-        self.item._data['reviewed'] = Stamp(None)
-        self.assertTrue(self.item.validate())
-        self.assertEqual(Stamp(None), self.item._data['reviewed'])
-
-    @patch('doorstop.settings.ERROR_ALL', True)
-    def test_validate_reviewed_second(self):
-        """Verify that a modified stamp fails review."""
-        self.item._data['reviewed'] = Stamp('abc123')
-        with ListLogHandler(core.base.log) as handler:
-            self.assertFalse(self.item.validate())
-            self.assertIn("unreviewed changes", handler.records)
-
-    def test_validate_cleared(self):
-        """Verify that checking a cleared link updates the stamp."""
-        mock_item = Mock()
-        mock_item.stamp = Mock(return_value=Stamp('abc123'))
-        mock_tree = MagicMock()
-        mock_tree.find_item = Mock(return_value=mock_item)
-        self.item.tree = mock_tree
-        self.item.links = [{'mock_uid': True}]
-        self.item.disable_get_issues_document()
-        self.assertTrue(self.item.validate())
-        self.assertEqual('abc123', self.item.links[0].stamp)
-
-    def test_validate_cleared_new(self):
-        """Verify that new links are stamped automatically."""
-        mock_item = Mock()
-        mock_item.stamp = Mock(return_value=Stamp('abc123'))
-        mock_tree = MagicMock()
-        mock_tree.find_item = Mock(return_value=mock_item)
-        self.item.tree = mock_tree
-        self.item.links = [{'mock_uid': None}]
-        self.item.disable_get_issues_document()
-        self.assertTrue(self.item.validate())
-        self.assertEqual('abc123', self.item.links[0].stamp)
-
-    def test_validate_nonnormative_with_links(self):
-        """Verify a non-normative item with links can be checked."""
-        self.item.normative = False
-        self.item.links = ['a']
-        self.item.disable_get_issues_document()
-        self.assertTrue(self.item.validate())
-
-    @patch('doorstop.settings.STAMP_NEW_LINKS', False)
-    def test_validate_link_to_inactive(self):
-        """Verify a link to an inactive item can be checked."""
-        mock_item = Mock()
-        mock_item.active = False
-        mock_tree = MagicMock()
-        mock_tree.find_item = Mock(return_value=mock_item)
-        self.item.links = ['a']
-        self.item.tree = mock_tree
-        self.item.disable_get_issues_document()
-        self.assertTrue(self.item.validate())
-
-    @patch('doorstop.settings.STAMP_NEW_LINKS', False)
-    def test_validate_link_to_nonnormative(self):
-        """Verify a link to an non-normative item can be checked."""
-        mock_item = Mock()
-        mock_item.normative = False
-        mock_tree = MagicMock()
-        mock_tree.find_item = Mock(return_value=mock_item)
-        self.item.links = ['a']
-        self.item.tree = mock_tree
-        self.item.disable_get_issues_document()
-        self.assertTrue(self.item.validate())
-
-    def test_validate_document(self):
-        """Verify an item can be checked against a document."""
-        self.item.document.parent = 'fake'
-        self.assertTrue(self.item.validate())
-
-    def test_validate_document_with_links(self):
-        """Verify an item can be checked against a document with links."""
-        self.item.link('unknown1')
-        self.item.document.parent = 'fake'
-        self.assertTrue(self.item.validate())
-
-    def test_validate_document_with_bad_link_uids(self):
-        """Verify an item can be checked against a document w/ bad links."""
-        self.item.link('invalid')
-        self.item.document.parent = 'fake'
-        with ListLogHandler(core.base.log) as handler:
-            self.assertFalse(self.item.validate())
-            self.assertIn("invalid UID in links: invalid", handler.records)
-
-    @patch('doorstop.settings.STAMP_NEW_LINKS', False)
-    def test_validate_tree(self):
-        """Verify an item can be checked against a tree."""
-
-        def mock_iter(self):  # pylint: disable=W0613
-            """Mock Tree.__iter__ to yield a mock Document."""
-            mock_document = Mock()
-            mock_document.parent = 'RQ'
-
-            def mock_iter2(self):  # pylint: disable=W0613
-                """Mock Document.__iter__ to yield a mock Item."""
-                mock_item = Mock()
-                mock_item.uid = 'TST001'
-                mock_item.links = ['RQ001']
-                yield mock_item
-
-            mock_document.__iter__ = mock_iter2
-            yield mock_document
-
-        self.item.link('fake1')
-
-        mock_tree = Mock()
-        mock_tree.__iter__ = mock_iter
-        mock_tree.find_item = lambda uid: Mock(uid='fake1')
-
-        self.item.tree = mock_tree
-
-        self.assertTrue(self.item.validate())
-
-    def test_validate_tree_error(self):
-        """Verify an item can be checked against a tree with errors."""
-        self.item.link('fake1')
-        mock_tree = MagicMock()
-        mock_tree.find_item = Mock(side_effect=DoorstopError)
-        self.item.tree = mock_tree
-        with ListLogHandler(core.base.log) as handler:
-            self.assertFalse(self.item.validate())
-            self.assertIn("linked to unknown item: fake1", handler.records)
-
-    @patch('doorstop.settings.REVIEW_NEW_ITEMS', False)
-    def test_validate_both(self):
-        """Verify an item can be checked against both."""
-
-        def mock_iter(seq):
-            """Create a mock __iter__ method."""
-
-            def _iter(self):  # pylint: disable=W0613
-                """Mock __iter__method."""
-                yield from seq
-
-            return _iter
-
-        mock_item = Mock()
-        mock_item.links = [self.item.uid]
-
-        self.item.document.parent = 'BOTH'
-        self.item.document.prefix = 'BOTH'
-        self.item.document.set_items([mock_item])
-
-        mock_tree = Mock()
-        mock_tree.__iter__ = mock_iter([self.item.document])
-        self.item.tree = mock_tree
-
-        self.assertTrue(self.item.validate())
-
-    @patch('doorstop.settings.STAMP_NEW_LINKS', False)
-    @patch('doorstop.settings.REVIEW_NEW_ITEMS', False)
-    def test_validate_both_no_reverse_links(self):
-        """Verify an item can be checked against both (no reverse links)."""
-
-        def mock_iter(self):  # pylint: disable=W0613
-            """Mock Tree.__iter__ to yield a mock Document."""
-            mock_document = Mock()
-            mock_document.parent = 'RQ'
-
-            def mock_iter2(self):  # pylint: disable=W0613
-                """Mock Document.__iter__ to yield a mock Item."""
-                mock_item = Mock()
-                mock_item.uid = 'TST001'
-                mock_item.links = []
-                yield mock_item
-
-            mock_document.__iter__ = mock_iter2
-            yield mock_document
-
-        self.item.link('fake1')
-
-        mock_tree = Mock()
-        mock_tree.__iter__ = mock_iter
-        mock_tree.find_item = lambda uid: Mock(uid='fake1')
-        self.item.tree = mock_tree
-
-        self.assertTrue(self.item.validate())
-
-    @patch('doorstop.core.item.Item.get_issues', Mock(return_value=[]))
-    def test_issues(self):
-        """Verify an item's issues convenience property can be accessed."""
-        self.assertEqual(0, len(self.item.issues))
-
     def test_stamp(self):
         """Verify an item's contents can be stamped."""
         stamp = 'c6a87755b8756b61731c704c6a7be4a2'
@@ -1056,10 +845,9 @@ class TestUnknownItem(unittest.TestCase):
         """Verify all other `Item` attributes raise an exception."""
         self.assertRaises(AttributeError, getattr, self.item, 'path')
         self.assertRaises(AttributeError, getattr, self.item, 'text')
-        self.assertRaises(AttributeError, getattr, self.item, 'get_issues')
         self.assertRaises(AttributeError, getattr, self.item, 'delete')
         self.assertRaises(AttributeError, getattr, self.item, 'not_on_item')
-        self.assertEqual(3, mock_warning.call_count)
+        self.assertEqual(2, mock_warning.call_count)
 
     @patch('doorstop.core.item.log.debug')
     def test_attributes_with_spec(self, mock_warning):
@@ -1068,10 +856,9 @@ class TestUnknownItem(unittest.TestCase):
         self.item = UnknownItem(self.item.uid, spec=spec)
         self.assertRaises(AttributeError, getattr, self.item, 'path')
         self.assertRaises(AttributeError, getattr, self.item, 'text')
-        self.assertRaises(AttributeError, getattr, self.item, 'get_issues')
         self.assertRaises(AttributeError, getattr, self.item, 'delete')
         self.assertRaises(AttributeError, getattr, self.item, 'not_on_item')
-        self.assertEqual(4, mock_warning.call_count)
+        self.assertEqual(3, mock_warning.call_count)
 
     def test_stamp(self):
         """Verify an unknown item has no stamp."""

--- a/doorstop/core/tests/test_item_validator.py
+++ b/doorstop/core/tests/test_item_validator.py
@@ -1,0 +1,249 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+# pylint: disable=C0302
+
+"""Unit tests for the doorstop.core.validators.item_validator module."""
+
+import logging
+import os
+import unittest
+from typing import List
+from unittest.mock import MagicMock, Mock, patch
+
+from doorstop import core
+from doorstop.common import DoorstopError
+from doorstop.core.tests import MockItem, MockItemValidator, MockSimpleDocument
+from doorstop.core.types import Stamp
+
+
+class ListLogHandler(logging.NullHandler):
+    def __init__(self, log):
+        super().__init__()
+        self.records: List[str] = []
+        self.log = log
+
+    def __enter__(self):
+        self.log.addHandler(self)
+        return self
+
+    def __exit__(self, kind, value, traceback):
+        self.log.removeHandler(self)
+
+    def handle(self, record):
+        self.records.append(str(record.msg))
+
+
+class TestItemValidator(unittest.TestCase):
+    """Unit tests for the ItemValidator class."""
+
+    # pylint: disable=protected-access,no-value-for-parameter
+
+    def setUp(self):
+        path = os.path.join('path', 'to', 'RQ001.yml')
+        self.item = MockItem(MockSimpleDocument(), path)
+        self.item_validator = MockItemValidator()
+
+    def test_validate_invalid_ref(self):
+        """Verify an invalid reference fails validity."""
+        with patch(
+            'doorstop.core.item.Item.find_ref',
+            Mock(side_effect=DoorstopError("test invalid ref")),
+        ):
+            with ListLogHandler(core.validators.item_validator.log) as handler:
+                self.assertFalse(self.item_validator.validate(self.item))
+                self.assertIn("test invalid ref", handler.records)
+
+    def test_validate_inactive(self):
+        """Verify an inactive item is not checked."""
+        self.item.active = False
+        with patch('doorstop.core.item.Item.find_ref', Mock(side_effect=DoorstopError)):
+            self.assertTrue(self.item_validator.validate(self.item))
+
+    def test_validate_reviewed(self):
+        """Verify that checking a reviewed item updates the stamp."""
+        self.item._data['reviewed'] = True
+        self.assertTrue(self.item_validator.validate(self.item))
+        stamp = 'c6a87755b8756b61731c704c6a7be4a2'
+        self.assertEqual(stamp, self.item._data['reviewed'])
+
+    @patch('doorstop.settings.REVIEW_NEW_ITEMS', False)
+    def test_validate_reviewed_first(self):
+        """Verify that a missing initial review leaves the stamp empty."""
+        self.item._data['reviewed'] = Stamp(None)
+        self.assertTrue(self.item_validator.validate(self.item))
+        self.assertEqual(Stamp(None), self.item._data['reviewed'])
+
+    @patch('doorstop.settings.ERROR_ALL', True)
+    def test_validate_reviewed_second(self):
+        """Verify that a modified stamp fails review."""
+        self.item._data['reviewed'] = Stamp('abc123')
+        with ListLogHandler(core.validators.item_validator.log) as handler:
+            self.assertFalse(self.item_validator.validate(self.item))
+            self.assertIn("unreviewed changes", handler.records)
+
+    def test_validate_cleared(self):
+        """Verify that checking a cleared link updates the stamp."""
+        mock_item = Mock()
+        mock_item.stamp = Mock(return_value=Stamp('abc123'))
+        mock_tree = MagicMock()
+        mock_tree.find_item = Mock(return_value=mock_item)
+        self.item.tree = mock_tree
+        self.item.links = [{'mock_uid': True}]
+        self.item_validator.disable_get_issues_document()
+        self.assertTrue(self.item_validator.validate(self.item))
+        self.assertEqual('abc123', self.item.links[0].stamp)
+
+    def test_validate_cleared_new(self):
+        """Verify that new links are stamped automatically."""
+        mock_item = Mock()
+        mock_item.stamp = Mock(return_value=Stamp('abc123'))
+        mock_tree = MagicMock()
+        mock_tree.find_item = Mock(return_value=mock_item)
+        self.item.tree = mock_tree
+        self.item.links = [{'mock_uid': None}]
+        self.item_validator.disable_get_issues_document()
+        self.assertTrue(self.item_validator.validate(self.item))
+        self.assertEqual('abc123', self.item.links[0].stamp)
+
+    def test_validate_nonnormative_with_links(self):
+        """Verify a non-normative item with links can be checked."""
+        self.item.normative = False
+        self.item.links = ['a']
+        self.item_validator.disable_get_issues_document()
+        self.assertTrue(self.item_validator.validate(self.item))
+
+    @patch('doorstop.settings.STAMP_NEW_LINKS', False)
+    def test_validate_link_to_inactive(self):
+        """Verify a link to an inactive item can be checked."""
+        mock_item = Mock()
+        mock_item.active = False
+        mock_tree = MagicMock()
+        mock_tree.find_item = Mock(return_value=mock_item)
+        self.item.links = ['a']
+        self.item.tree = mock_tree
+        self.item_validator.disable_get_issues_document()
+        self.assertTrue(self.item_validator.validate(self.item))
+
+    @patch('doorstop.settings.STAMP_NEW_LINKS', False)
+    def test_validate_link_to_nonnormative(self):
+        """Verify a link to an non-normative item can be checked."""
+        mock_item = Mock()
+        mock_item.normative = False
+        mock_tree = MagicMock()
+        mock_tree.find_item = Mock(return_value=mock_item)
+        self.item.links = ['a']
+        self.item.tree = mock_tree
+        self.item_validator.disable_get_issues_document()
+        self.assertTrue(self.item_validator.validate(self.item))
+
+    def test_validate_document(self):
+        """Verify an item can be checked against a document."""
+        self.item.document.parent = 'fake'
+        self.assertTrue(self.item_validator.validate(self.item))
+
+    def test_validate_document_with_links(self):
+        """Verify an item can be checked against a document with links."""
+        self.item.link('unknown1')
+        self.item.document.parent = 'fake'
+        self.assertTrue(self.item_validator.validate(self.item))
+
+    def test_validate_document_with_bad_link_uids(self):
+        """Verify an item can be checked against a document w/ bad links."""
+        self.item.link('invalid')
+        self.item.document.parent = 'fake'
+        with ListLogHandler(core.validators.item_validator.log) as handler:
+            self.assertFalse(self.item_validator.validate(self.item))
+            self.assertIn("invalid UID in links: invalid", handler.records)
+
+    @patch('doorstop.settings.STAMP_NEW_LINKS', False)
+    def test_validate_tree(self):
+        """Verify an item can be checked against a tree."""
+
+        def mock_iter(self):  # pylint: disable=W0613
+            """Mock Tree.__iter__ to yield a mock Document."""
+            mock_document = Mock()
+            mock_document.parent = 'RQ'
+
+            def mock_iter2(self):  # pylint: disable=W0613
+                """Mock Document.__iter__ to yield a mock Item."""
+                mock_item = Mock()
+                mock_item.uid = 'TST001'
+                mock_item.links = ['RQ001']
+                yield mock_item
+
+            mock_document.__iter__ = mock_iter2
+            yield mock_document
+
+        self.item.link('fake1')
+
+        mock_tree = Mock()
+        mock_tree.__iter__ = mock_iter
+        mock_tree.find_item = lambda uid: Mock(uid='fake1')
+
+        self.item.tree = mock_tree
+
+        self.assertTrue(self.item_validator.validate(self.item))
+
+    def test_validate_tree_error(self):
+        """Verify an item can be checked against a tree with errors."""
+        self.item.link('fake1')
+        mock_tree = MagicMock()
+        mock_tree.find_item = Mock(side_effect=DoorstopError)
+        self.item.tree = mock_tree
+        with ListLogHandler(core.validators.item_validator.log) as handler:
+            self.assertFalse(self.item_validator.validate(self.item))
+            self.assertIn("linked to unknown item: fake1", handler.records)
+
+    @patch('doorstop.settings.REVIEW_NEW_ITEMS', False)
+    def test_validate_both(self):
+        """Verify an item can be checked against both."""
+
+        def mock_iter(seq):
+            """Create a mock __iter__ method."""
+
+            def _iter(self):  # pylint: disable=W0613
+                """Mock __iter__method."""
+                yield from seq
+
+            return _iter
+
+        mock_item = Mock()
+        mock_item.links = [self.item.uid]
+
+        self.item.document.parent = 'BOTH'
+        self.item.document.prefix = 'BOTH'
+        self.item.document.set_items([mock_item])
+
+        mock_tree = Mock()
+        mock_tree.__iter__ = mock_iter([self.item.document])
+        self.item.tree = mock_tree
+
+        self.assertTrue(self.item_validator.validate(self.item))
+
+    @patch('doorstop.settings.STAMP_NEW_LINKS', False)
+    @patch('doorstop.settings.REVIEW_NEW_ITEMS', False)
+    def test_validate_both_no_reverse_links(self):
+        """Verify an item can be checked against both (no reverse links)."""
+
+        def mock_iter(self):  # pylint: disable=W0613
+            """Mock Tree.__iter__ to yield a mock Document."""
+            mock_document = Mock()
+            mock_document.parent = 'RQ'
+
+            def mock_iter2(self):  # pylint: disable=W0613
+                """Mock Document.__iter__ to yield a mock Item."""
+                mock_item = Mock()
+                mock_item.uid = 'TST001'
+                mock_item.links = []
+                yield mock_item
+
+            mock_document.__iter__ = mock_iter2
+            yield mock_document
+
+        self.item.link('fake1')
+
+        mock_tree = Mock()
+        mock_tree.__iter__ = mock_iter
+        mock_tree.find_item = lambda uid: Mock(uid='fake1')
+        self.item.tree = mock_tree
+
+        self.assertTrue(self.item_validator.validate(self.item))

--- a/doorstop/core/validators/item_validator.py
+++ b/doorstop/core/validators/item_validator.py
@@ -1,0 +1,221 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+
+"""Class ItemValidator for validation of Item objects."""
+
+from doorstop import common, settings
+from doorstop.common import DoorstopError, DoorstopInfo, DoorstopWarning
+from doorstop.core.types import UID, Stamp
+
+log = common.logger(__name__)
+
+
+class ItemValidator:
+    """Class for validation of Item objects."""
+
+    def validate(self, item, skip=None, document_hook=None, item_hook=None):
+        """Check the object for validity.
+
+        :param item: item to validate
+        :param skip: list of document prefixes to skip
+        :param document_hook: function to call for custom document
+            validation
+        :param item_hook: function to call for custom item validation
+
+        :return: indication that the object is valid
+
+        """
+        valid = True
+        # Display all issues
+        for issue in self.get_issues(
+            item, skip=skip, document_hook=document_hook, item_hook=item_hook
+        ):
+            if isinstance(issue, DoorstopInfo) and not settings.WARN_ALL:
+                log.info(issue)
+            elif isinstance(issue, DoorstopWarning) and not settings.ERROR_ALL:
+                log.warning(issue)
+            else:
+                assert isinstance(issue, DoorstopError)
+                log.error(issue)
+                valid = False
+        # Return the result
+        return valid
+
+    def get_issues(
+        self, item, skip=None, document_hook=None, item_hook=None
+    ):  # pylint: disable=unused-argument
+        """Yield all the item's issues.
+
+        :param skip: list of document prefixes to skip
+
+        :return: generator of :class:`~doorstop.common.DoorstopError`,
+                              :class:`~doorstop.common.DoorstopWarning`,
+                              :class:`~doorstop.common.DoorstopInfo`
+
+        """
+        assert document_hook is None
+        assert item_hook is None
+        skip = [] if skip is None else skip
+
+        log.info("checking item %s...", item)
+
+        # Verify the file can be parsed
+        item.load()
+
+        # Skip inactive items
+        if not item.active:
+            log.info("skipped inactive item: %s", item)
+            return
+
+        # Delay item save if reformatting
+        if settings.REFORMAT:
+            item.auto = False
+
+        # Check text
+        if not item.text:
+            yield DoorstopWarning("no text")
+
+        # Check external references
+        if settings.CHECK_REF:
+            try:
+                item.find_ref()
+            except DoorstopError as exc:
+                yield exc
+
+        # Check links
+        if not item.normative and item.links:
+            yield DoorstopWarning("non-normative, but has links")
+
+        # Check links against the document
+        yield from self._get_issues_document(item, item.document, skip)
+
+        if item.tree:
+            # Check links against the tree
+            yield from self._get_issues_tree(item, item.tree)
+
+            # Check links against both document and tree
+            yield from self._get_issues_both(item, item.document, item.tree, skip)
+
+        # Check review status
+        if not item.reviewed:
+            if settings.CHECK_REVIEW_STATUS:
+                if item.is_reviewed():
+                    if settings.REVIEW_NEW_ITEMS:
+                        item.review()
+                    else:
+                        yield DoorstopInfo("needs initial review")
+                else:
+                    yield DoorstopWarning("unreviewed changes")
+
+        # Reformat the file
+        if settings.REFORMAT:
+            log.debug("reformatting item %s...", item)
+            item.save()
+
+    @staticmethod
+    def _get_issues_document(item, document, skip):
+        """Yield all the item's issues against its document."""
+        log.debug("getting issues against document...")
+
+        if document in skip:
+            log.debug("skipping issues against document %s...", document)
+            return
+
+        # Verify an item's UID matches its document's prefix
+        if item.prefix != document.prefix:
+            msg = "prefix differs from document ({})".format(document.prefix)
+            yield DoorstopInfo(msg)
+
+        # Verify that normative, non-derived items in a child document have at
+        # least one link.  It is recommended that these items have an upward
+        # link to an item in the parent document, however, this is not
+        # enforced.  An info message is generated if this is not the case.
+        if all((document.parent, item.normative, not item.derived)) and not item.links:
+            msg = "no links to parent document: {}".format(document.parent)
+            yield DoorstopWarning(msg)
+
+        # Verify an item's links are to the correct parent
+        for uid in item.links:
+            try:
+                prefix = uid.prefix
+            except DoorstopError:
+                msg = "invalid UID in links: {}".format(uid)
+                yield DoorstopError(msg)
+            else:
+                if document.parent and prefix != document.parent:
+                    # this is only 'info' because a document is allowed
+                    # to contain items with a different prefix, but
+                    # Doorstop will not create items like this
+                    msg = "parent is '{}', but linked to: {}".format(
+                        document.parent, uid
+                    )
+                    yield DoorstopInfo(msg)
+
+    def _get_issues_tree(self, item, tree):
+        """Yield all the item's issues against its tree."""
+        log.debug("getting issues against tree...")
+
+        # Verify an item's links are valid
+        identifiers = set()
+        for uid in item.links:
+            try:
+                item = tree.find_item(uid)
+            except DoorstopError:
+                identifiers.add(uid)  # keep the invalid UID
+                msg = "linked to unknown item: {}".format(uid)
+                yield DoorstopError(msg)
+            else:
+                # check the linked item
+                if not item.active:
+                    msg = "linked to inactive item: {}".format(item)
+                    yield DoorstopInfo(msg)
+                if not item.normative:
+                    msg = "linked to non-normative item: {}".format(item)
+                    yield DoorstopWarning(msg)
+                # check the link status
+                if uid.stamp == Stamp(True):
+                    uid.stamp = item.stamp()
+                elif not str(uid.stamp) and settings.STAMP_NEW_LINKS:
+                    uid.stamp = item.stamp()
+                elif uid.stamp != item.stamp():
+                    if settings.CHECK_SUSPECT_LINKS:
+                        msg = "suspect link: {}".format(item)
+                        yield DoorstopWarning(msg)
+                # reformat the item's UID
+                identifier2 = UID(item.uid, stamp=uid.stamp)
+                identifiers.add(identifier2)
+
+        # Apply the reformatted item UIDs
+        if settings.REFORMAT:
+            item.set_links(identifiers)
+
+    def _get_issues_both(self, item, document, tree, skip):
+        """Yield all the item's issues against its document and tree."""
+        log.debug("getting issues against document and tree...")
+
+        if document.prefix in skip:
+            log.debug("skipping issues against document %s...", document)
+            return
+
+        # Verify an item is being linked to (child links)
+        if settings.CHECK_CHILD_LINKS and item.normative:
+            find_all = settings.CHECK_CHILD_LINKS_STRICT or False
+            items, documents = item.find_child_items_and_documents(
+                document=document, tree=tree, find_all=find_all
+            )
+
+            if not items:
+                for child_document in documents:
+                    if document.prefix in skip:
+                        msg = "skipping issues against document %s..."
+                        log.debug(msg, child_document)
+                        continue
+                    msg = "no links from child document: {}".format(child_document)
+                    yield DoorstopWarning(msg)
+            elif settings.CHECK_CHILD_LINKS_STRICT:
+                prefix = [item.prefix for item in items]
+                for child in document.children:
+                    if child in skip:
+                        continue
+                    if child not in prefix:
+                        msg = 'no links from document: {}'.format(child)
+                        yield DoorstopWarning(msg)


### PR DESCRIPTION
The Item class is very close to hitting 1000 lines limit which indicates that it probably does too many things.

As discussed in https://github.com/doorstop-dev/doorstop/issues/409, which identified some possible targets for refactoring, the validation aspects could be moved to a separate module.

This changeset moves all 4 validation-related functions to a separate class: `ItemValidator`.

With this change, `Item` is no longer `BaseValidatable` which seems reasonable, because otherwise it would be hard to move these 4 functions out without introducing cyclic dependencies.