### PR TITLE
Item and ItemValidator: fix a minor bug introduced by recent refactoring

### DIFF
--- a/doorstop/core/item.py
+++ b/doorstop/core/item.py
@@ -553,7 +553,7 @@ class Item(BaseFileObject):  # pylint: disable=R0902
             log.warning("link to {0} does not exist".format(uid))
 
     def is_reviewed(self):
-        return not self._data['reviewed']
+        return self._data['reviewed']
 
     def set_links(self, links):
         self._data['links'] = links

--- a/doorstop/core/validators/item_validator.py
+++ b/doorstop/core/validators/item_validator.py
@@ -98,7 +98,7 @@ class ItemValidator:
         # Check review status
         if not item.reviewed:
             if settings.CHECK_REVIEW_STATUS:
-                if item.is_reviewed():
+                if not item.is_reviewed():
                     if settings.REVIEW_NEW_ITEMS:
                         item.review()
                     else:


### PR DESCRIPTION
P.S. This code is checking `reviewed` two times. It was not introduced by my change, but my change made this more obvious. This could be reviewed and improved later at some point.

```python
        ...
         if not item.reviewed:
            if settings.CHECK_REVIEW_STATUS:
                if not item.is_reviewed():
        ...
```
