### PR TITLE
Uid name

### DIFF
--- a/docs/cli/creation.md
+++ b/docs/cli/creation.md
@@ -65,6 +65,64 @@ text: 'My default text.'
 The command line specified default values override values from the document
 configuration.
 
+# Add Items with a Name in the UID
+
+By default, new items get a number assigned by Doorstop for their UID together
+with the document prefix and separator.  Doorstop allows you to specifiy an
+explicit number or a name for the item UID.  Names can be only used if the
+document was created with a separator.  Names cannot contain separators.
+Allowed separators are '-', '\_', and '.'.
+
+As an example, we create a document with a '-' separator:
+```sh
+$ doorstop create -s - REQ ./reqs
+building tree...
+created document: REQ (@/reqs)
+```
+
+You can add items as normal:
+```sh
+$ doorstop add REQ
+building tree...
+added item: REQ-001 (@/reqs/REQ-001.yml)
+```
+
+The first item has an UID of `REQ-001`.  Please note that this UID has the
+separator of the document included.  You can specify the number part of the UID
+for a new item:
+```sh
+$ doorstop add -n 3 REQ
+building tree...
+added item: REQ-003 (@/reqs/REQ-003.yml)
+```
+
+You can specify the name part of the UID for a new item:
+```sh
+$ doorstop add -n FOOBAR REQ
+building tree...
+added item: REQ-FOOBAR (@/reqs/REQ-FOOBAR.yml)
+```
+
+You can continue to add items as normal:
+```sh
+$ doorstop add REQ
+building tree...
+added item: REQ-004 (@/reqs/REQ-004.yml)
+```
+
+Your document contains now the following items:
+```sh
+$ doorstop publish REQ
+building tree...
+1.0     REQ-001
+
+1.1     REQ-003
+
+1.2     REQ-FOOBAR
+
+1.3     REQ-004
+```
+
 # Document Configuration
 
 The settings and attribute options of each document are stored in a

--- a/docs/reference/item.md
+++ b/docs/reference/item.md
@@ -8,7 +8,7 @@ number or name. The two parts are divided by an optional separator. The prefix
 and separator are determined by the document to which the item belongs. By
 default, the number is automatically assigned by Doorstop. Optionally, a user
 can specify a name for the UID during item creation. The name must not contain
-separator characters or digits.
+separator characters.
 
 Example item:
 ```yaml

--- a/docs/reference/item.md
+++ b/docs/reference/item.md
@@ -4,9 +4,11 @@ Doorstop items are files formatted using YAML. When a new item is added using
 `doorstop add`, Doorstop will create a YAML file and populate it with all
 required attributes (key-value pairs). The UID of an item is defined by its
 file name without the extension. An UID consists of two parts, the prefix and a
-number. The parts are divided by an optional separator. The prefix is
-determined by the document to which the item belongs. The number is
-automatically assigned by Doorstop.
+number or name. The two parts are divided by an optional separator. The prefix
+and separator are determined by the document to which the item belongs. By
+default, the number is automatically assigned by Doorstop. Optionally, a user
+can specify a name for the UID during item creation. The name must not contain
+separator characters or digits.
 
 Example item:
 ```yaml

--- a/doorstop/cli/commands.py
+++ b/doorstop/cli/commands.py
@@ -183,7 +183,9 @@ def run_add(args, cwd, _, catch=True):
 
         # add items to it
         for _ in range(args.count):
-            item = document.add_item(level=args.level, defaults=args.defaults)
+            item = document.add_item(
+                level=args.level, defaults=args.defaults, name=args.name
+            )
             utilities.show("added item: {} ({})".format(item.uid, item.relpath))
 
         # Edit item if requested

--- a/doorstop/cli/commands.py
+++ b/doorstop/cli/commands.py
@@ -122,7 +122,11 @@ def run_create(args, cwd, _, catch=True):
 
         # create a new document
         document = tree.create_document(
-            args.path, args.prefix, parent=args.parent, digits=args.digits
+            args.path,
+            args.prefix,
+            parent=args.parent,
+            digits=args.digits,
+            sep=args.separator,
         )
 
     if not success:

--- a/doorstop/cli/main.py
+++ b/doorstop/cli/main.py
@@ -234,11 +234,13 @@ def _add(subs, shared):
     sub.add_argument(
         '-n',
         '--name',
+        '--number',
+        metavar='NANU',
         help=(
-            "use the specified NAME instead of an automatically "
+            "use the specified name or number NANU instead of an automatically "
             "generated number for the UID (together with the document prefix "
-            "and separator); the NAME must not contain separator characters "
-            "or digits"
+            "and separator); the NANU must be a number or a string which does "
+            "not contain separator characters or digits"
         ),
     )
     sub.add_argument(

--- a/doorstop/cli/main.py
+++ b/doorstop/cli/main.py
@@ -202,6 +202,16 @@ def _create(subs, shared):
         help="number of digits in item UIDs",
         default=document.Document.DEFAULT_DIGITS,
     )
+    sub.add_argument(
+        '-s',
+        '--separator',
+        metavar='SEP',
+        help=(
+            "separator between the prefix and the number or name in an "
+            "item UID; the only valid separators are '-', '_', and '.'"
+        ),
+        default=document.Document.DEFAULT_SEP,
+    )
 
 
 def _delete(subs, shared):

--- a/doorstop/cli/main.py
+++ b/doorstop/cli/main.py
@@ -232,6 +232,16 @@ def _add(subs, shared):
     sub.add_argument('prefix', help="document prefix for the new item")
     sub.add_argument('-l', '--level', help="desired item level (e.g. 1.2.3)")
     sub.add_argument(
+        '-n',
+        '--name',
+        help=(
+            "use the specified NAME instead of an automatically "
+            "generated number for the UID (together with the document prefix "
+            "and separator); the NAME must not contain separator characters "
+            "or digits"
+        ),
+    )
+    sub.add_argument(
         '-c',
         '--count',
         default=1,

--- a/doorstop/cli/main.py
+++ b/doorstop/cli/main.py
@@ -240,7 +240,7 @@ def _add(subs, shared):
             "use the specified name or number NANU instead of an automatically "
             "generated number for the UID (together with the document prefix "
             "and separator); the NANU must be a number or a string which does "
-            "not contain separator characters or digits"
+            "not contain separator characters"
         ),
     )
     sub.add_argument(

--- a/doorstop/cli/tests/test_all.py
+++ b/doorstop/cli/tests/test_all.py
@@ -201,7 +201,7 @@ class TestAddServer(unittest.TestCase):
     def test_add_custom_server(self, mock_add_item):
         """Verify 'doorstop add' can be called with a custom server."""
         self.assertIs(None, main(['add', 'TUT', '--server', '1.2.3.4']))
-        mock_add_item.assert_called_once_with(defaults=None, level=None)
+        mock_add_item.assert_called_once_with(defaults=None, level=None, name=None)
 
     def test_add_force(self):
         """Verify 'doorstop add' can be called with a missing server."""

--- a/doorstop/cli/tests/test_all.py
+++ b/doorstop/cli/tests/test_all.py
@@ -417,6 +417,12 @@ class TestClear(unittest.TestCase):
         self.assertIs(None, main(['clear', 'tut2']))
         self.assertEqual(1, mock_clear.call_count)
 
+    @patch('doorstop.core.item.Item.clear')
+    def test_clear_item_parent(self, mock_clear):
+        """Verify 'doorstop clear' can be called with an item and parent."""
+        self.assertIs(None, main(['clear', 'tut2', 'req2']))
+        self.assertEqual(1, mock_clear.call_count)
+
     def test_clear_item_unknown(self):
         """Verify 'doorstop clear' returns an error on an unknown item."""
         self.assertRaises(SystemExit, main, ['clear', '--item', 'FAKE001'])

--- a/doorstop/cli/tests/tutorial.py
+++ b/doorstop/cli/tests/tutorial.py
@@ -247,6 +247,36 @@ class TestSection1(TestBase):
             cp.stdout,
         )
 
+    def test_item_with_name(self):
+        """Verify new item with custom defaults is working."""
+
+        self.doorstop("create -s - REQ .")
+
+        self.doorstop("add -n ABC REQ")
+        self.assertTrue(os.path.isfile('REQ-ABC.yml'))
+
+        self.doorstop("add -n 9 REQ")
+        self.assertTrue(os.path.isfile('REQ-009.yml'))
+
+        self.doorstop("add -n XYZ REQ")
+        self.assertTrue(os.path.isfile('REQ-XYZ.yml'))
+
+        self.doorstop("add -n 99 REQ")
+        self.assertTrue(os.path.isfile('REQ-099.yml'))
+
+        cp = self.doorstop("publish REQ", stdout=subprocess.PIPE)
+        self.assertIn(
+            b'''1.0     REQ-ABC
+
+1.1     REQ-009
+
+1.2     REQ-XYZ
+
+1.3     REQ-099
+''',
+            cp.stdout,
+        )
+
 
 if __name__ == '__main__':
     logging.basicConfig(format="%(message)s", level=logging.INFO)

--- a/doorstop/cli/tests/tutorial.py
+++ b/doorstop/cli/tests/tutorial.py
@@ -258,10 +258,10 @@ class TestSection1(TestBase):
         self.doorstop("add -n 9 REQ")
         self.assertTrue(os.path.isfile('REQ-009.yml'))
 
-        self.doorstop("add -n XYZ REQ")
+        self.doorstop("add --name XYZ REQ")
         self.assertTrue(os.path.isfile('REQ-XYZ.yml'))
 
-        self.doorstop("add -n 99 REQ")
+        self.doorstop("add --number 99 REQ")
         self.assertTrue(os.path.isfile('REQ-099.yml'))
 
         cp = self.doorstop("publish REQ", stdout=subprocess.PIPE)

--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -112,8 +112,10 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         :return: new :class:`~doorstop.core.document.Document`
 
         """
-        # TODO: raise a specific exception for invalid separator characters?
-        assert not sep or sep in settings.SEP_CHARS
+        # Check separator
+        if sep and sep not in settings.SEP_CHARS:
+            raise DoorstopError("invalid UID separator '{}'".format(sep))
+
         config = os.path.join(path, Document.CONFIG)
 
         # Check for an existing document

--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -426,7 +426,7 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
     # actions ################################################################
 
     # decorators are applied to methods in the associated classes
-    def add_item(self, number=None, level=None, reorder=True, defaults=None):
+    def add_item(self, number=None, level=None, reorder=True, defaults=None, name=None):
         """Create a new item for the document and return it.
 
         :param number: desired item number
@@ -436,8 +436,30 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         :return: added :class:`~doorstop.core.item.Item`
 
         """
-        number = max(number or 0, self.next_number)
-        log.debug("next number: {}".format(number))
+        uid = None
+        if name is None:
+            number = max(number or 0, self.next_number)
+            log.debug("next number: {}".format(number))
+            uid = UID(self.prefix, self.sep, number, self.digits)
+        else:
+            try:
+                uid = UID(self.prefix, self.sep, int(name), self.digits)
+            except ValueError:
+                if not self.sep:
+                    msg = "cannot add item with name '{}' to document '{}' without a separator".format(
+                        name, self.prefix
+                    )
+                    raise DoorstopError(msg)
+                if self.sep not in settings.SEP_CHARS:
+                    msg = "cannot add item with name '{}' to document '{}' with an invalid separator '{}'".format(
+                        name, self.prefix, self.sep
+                    )
+                    raise DoorstopError(msg)
+                uid = UID(self.prefix, self.sep, name)
+                if uid.prefix != self.prefix or uid.name != name:
+                    msg = "invalid item name '{}'".format(name)
+                    raise DoorstopError(msg)
+
         try:
             last = self.items[-1]
         except IndexError:
@@ -456,7 +478,6 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         # constructed items in case the loading fails.
         more_defaults = self._load_with_include(defaults) if defaults else None
 
-        uid = UID(self.prefix, self.sep, number, self.digits)
         item = Item.new(self.tree, self, self.path, self.root, uid, level=next_level)
         if self._attribute_defaults:
             item.set_attributes(self._attribute_defaults)

--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -381,7 +381,7 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
     def next_number(self):
         """Get the next item number for the document."""
         try:
-            number = max(item.number for item in self) + 1
+            number = max(item.uid.number for item in self) + 1
         except ValueError:
             number = 1
         log.debug("next number (local): {}".format(number))

--- a/doorstop/core/item.py
+++ b/doorstop/core/item.py
@@ -267,11 +267,6 @@ class Item(BaseFileObject):  # pylint: disable=R0902
         """Get the item UID's prefix."""
         return self.uid.prefix
 
-    @property
-    def number(self):
-        """Get the item UID's number."""
-        return self.uid.number
-
     @property  # type: ignore
     @auto_load
     def level(self):
@@ -748,7 +743,6 @@ class UnknownItem:
         return self._uid
 
     prefix = Item.prefix
-    number = Item.number
 
     @property
     def relpath(self):

--- a/doorstop/core/item.py
+++ b/doorstop/core/item.py
@@ -262,11 +262,6 @@ class Item(BaseFileObject):  # pylint: disable=R0902
         filename = os.path.basename(self.path)
         return UID(os.path.splitext(filename)[0])
 
-    @property
-    def prefix(self):
-        """Get the item UID's prefix."""
-        return self.uid.prefix
-
     @property  # type: ignore
     @auto_load
     def level(self):
@@ -741,8 +736,6 @@ class UnknownItem:
     def uid(self):
         """Get the item's UID."""
         return self._uid
-
-    prefix = Item.prefix
 
     @property
     def relpath(self):

--- a/doorstop/core/tests/test_document.py
+++ b/doorstop/core/tests/test_document.py
@@ -310,6 +310,13 @@ class TestDocument(unittest.TestCase):
         """Verify an exception is raised if the document already exists."""
         self.assertRaises(DoorstopError, Document.new, None, FILES, ROOT, prefix='DUPL')
 
+    def test_new_invalid_sep(self):
+        """Verify an exception is raised if the separator is invalid."""
+        msg = "invalid UID separator 'X'"
+        self.assertRaisesRegex(
+            DoorstopError, msg, Document.new, None, FILES, ROOT, prefix='NEW', sep='X'
+        )
+
     @patch('doorstop.core.document.Document', MockDocument)
     def test_new_cache(self):
         """Verify a new documents are cached."""

--- a/doorstop/core/tests/test_document.py
+++ b/doorstop/core/tests/test_document.py
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: LGPL-3.0-only
+# pylint: disable=C0302
 
 """Unit tests for the doorstop.core.document module."""
 
@@ -462,6 +463,47 @@ outline:
         self.document.add_item(number=999)
         mock_new.assert_called_once_with(
             None, self.document, FILES, ROOT, 'REQ999', level=Level('2.2')
+        )
+
+    def test_add_item_with_no_sep(self):
+        """Verify an item cannot be added to a document without a separator with a name."""
+        msg = "cannot add item with name 'ABC' to document 'REQ' without a separator"
+        self.assertRaisesRegex(DoorstopError, msg, self.document.add_item, name='ABC')
+
+    def test_add_item_with_invalid_sep(self):
+        """Verify an item cannot be added to a document with an invalid separator with a name."""
+        self.document._data['sep'] = 'X'
+        msg = "cannot add item with name 'ABC' to document 'REQ' with an invalid separator 'X'"
+        self.assertRaisesRegex(DoorstopError, msg, self.document.add_item, name='ABC')
+
+    def test_add_item_with_invalid_name(self):
+        """Verify an item cannot be added to a document with an invalid name."""
+        self.document.sep = '-'
+        msg = "invalid item name 'A-B'"
+        self.assertRaisesRegex(DoorstopError, msg, self.document.add_item, name='A-B')
+        msg = "invalid item name 'A_B'"
+        self.assertRaisesRegex(DoorstopError, msg, self.document.add_item, name='A_B')
+        msg = "invalid item name 'A.B'"
+        self.assertRaisesRegex(DoorstopError, msg, self.document.add_item, name='A.B')
+        msg = "invalid item name 'X/Y'"
+        self.assertRaisesRegex(DoorstopError, msg, self.document.add_item, name='X/Y')
+
+    @patch('doorstop.core.item.Item.new')
+    def test_add_item_with_name(self, mock_new):
+        """Verify an item can be added to a document with a name."""
+        self.document.sep = '-'
+        self.document.add_item(name='ABC')
+        mock_new.assert_called_once_with(
+            None, self.document, FILES, ROOT, 'REQ-ABC', level=Level('2.2')
+        )
+
+    @patch('doorstop.core.item.Item.new')
+    def test_add_item_with_number_name(self, mock_new):
+        """Verify an item can be added to a document with a number as name."""
+        self.document.sep = '-'
+        self.document.add_item(name='99')
+        mock_new.assert_called_once_with(
+            None, self.document, FILES, ROOT, 'REQ-099', level=Level('2.2')
         )
 
     @patch('doorstop.core.item.Item.set_attributes')

--- a/doorstop/core/tests/test_document.py
+++ b/doorstop/core/tests/test_document.py
@@ -14,7 +14,7 @@ from doorstop import common
 from doorstop.common import DoorstopError, DoorstopInfo, DoorstopWarning
 from doorstop.core.document import Document
 from doorstop.core.tests import EMPTY, FILES, NEW, ROOT, MockDocument, MockItem
-from doorstop.core.types import Level
+from doorstop.core.types import UID, Level
 
 YAML_DEFAULT = """
 settings:
@@ -485,7 +485,7 @@ outline:
     def test_add_item_after_header(self, mock_new):
         """Verify the next item after a header is indented."""
         mock_item = Mock()
-        mock_item.number = 1
+        mock_item.uid = UID('REQ001')
         mock_item.level = Level('1.0')
         self.document._iter = Mock(return_value=[mock_item])
         self.document.add_item()

--- a/doorstop/core/tests/test_item.py
+++ b/doorstop/core/tests/test_item.py
@@ -226,11 +226,6 @@ class TestItem(unittest.TestCase):
         self.assertEqual('RQ', self.item.prefix)
         self.assertRaises(AttributeError, setattr, self.item, 'prefix', 'REQ')
 
-    def test_number(self):
-        """Verify an item's number can be read but not set."""
-        self.assertEqual(1, self.item.number)
-        self.assertRaises(AttributeError, setattr, self.item, 'number', 2)
-
     def test_level(self):
         """Verify an item's level can be set and read."""
         self.item.level = (1, 2, 3)
@@ -836,11 +831,6 @@ class TestUnknownItem(unittest.TestCase):
         """Verify an item's prefix can be read but not set."""
         self.assertEqual('RQ', self.item.prefix)
         self.assertRaises(AttributeError, setattr, self.item, 'prefix', 'REQ')
-
-    def test_number(self):
-        """Verify an item's number can be read but not set."""
-        self.assertEqual(1, self.item.number)
-        self.assertRaises(AttributeError, setattr, self.item, 'number', 2)
 
     @patch('doorstop.core.item.log.debug')
     def test_attributes(self, mock_warning):

--- a/doorstop/core/tests/test_item.py
+++ b/doorstop/core/tests/test_item.py
@@ -221,11 +221,6 @@ class TestItem(unittest.TestCase):
         self.assertEqual(text, self.item.relpath)
         self.assertRaises(AttributeError, setattr, self.item, 'relpath', '.')
 
-    def test_prefix(self):
-        """Verify an item's prefix can be read but not set."""
-        self.assertEqual('RQ', self.item.prefix)
-        self.assertRaises(AttributeError, setattr, self.item, 'prefix', 'REQ')
-
     def test_level(self):
         """Verify an item's level can be set and read."""
         self.item.level = (1, 2, 3)
@@ -826,11 +821,6 @@ class TestUnknownItem(unittest.TestCase):
         text = "@{}{}".format(os.sep, '???')
         self.assertEqual(text, self.item.relpath)
         self.assertRaises(AttributeError, setattr, self.item, 'relpath', '.')
-
-    def test_prefix(self):
-        """Verify an item's prefix can be read but not set."""
-        self.assertEqual('RQ', self.item.prefix)
-        self.assertRaises(AttributeError, setattr, self.item, 'prefix', 'REQ')
 
     @patch('doorstop.core.item.log.debug')
     def test_attributes(self, mock_warning):

--- a/doorstop/core/tests/test_item.py
+++ b/doorstop/core/tests/test_item.py
@@ -816,6 +816,11 @@ class TestUnknownItem(unittest.TestCase):
         self.assertEqual('RQ001', self.item.uid)
         self.assertRaises(AttributeError, setattr, self.item, 'uid', 'RQ002')
 
+    def test_le(self):
+        """Verify unknown item's UID less operator."""
+        self.assertTrue(self.item < UnknownItem('RQ002'))
+        self.assertFalse(self.item < self.item)
+
     def test_relpath(self):
         """Verify an item's relative path string can be read but not set."""
         text = "@{}{}".format(os.sep, '???')

--- a/doorstop/core/tests/test_types.py
+++ b/doorstop/core/tests/test_types.py
@@ -107,6 +107,18 @@ class TestUID(unittest.TestCase):
         self.assertEqual('REQ.A-B', uid.prefix)
         self.assertEqual(-1, uid.number)
         self.assertEqual('C', uid.name)
+        uid = UID('REQ.A-B_1C more')
+        self.assertEqual('REQ.A-B', uid.prefix)
+        self.assertEqual(-1, uid.number)
+        self.assertEqual('1C', uid.name)
+        uid = UID('REQ.A-B_C2 more')
+        self.assertEqual('REQ.A-B', uid.prefix)
+        self.assertEqual(-1, uid.number)
+        self.assertEqual('C2', uid.name)
+        uid = UID('REQ.A-B_C3D more')
+        self.assertEqual('REQ.A-B', uid.prefix)
+        self.assertEqual(-1, uid.number)
+        self.assertEqual('C3D', uid.name)
 
     def test_init_values(self):
         """Verify UIDs are parsed correctly (values)."""

--- a/doorstop/core/tests/test_types.py
+++ b/doorstop/core/tests/test_types.py
@@ -56,11 +56,6 @@ class TestPrefix(unittest.TestCase):
         prefixes = [Prefix('a'), Prefix('B'), Prefix('c')]
         self.assertListEqual(prefixes, sorted(prefixes))
 
-    def test_short(self):
-        """Verify the short representation of prefixes is correct."""
-        self.assertEqual('req', self.prefix1.short)
-        self.assertEqual('tst', self.prefix2.short)
-
 
 class TestUID(unittest.TestCase):
     """Unit tests for the UID class."""  # pylint: disable=W0212
@@ -140,12 +135,6 @@ class TestUID(unittest.TestCase):
         self.assertEqual(1, self.uid1.number)
         self.assertEqual(2, self.uid2.number)
         self.assertEqual(3, self.uid3.number)
-
-    def test_short(self):
-        """Verify the short representation of IDs is correct."""
-        self.assertEqual('req1', self.uid1.short)
-        self.assertEqual('tst2', self.uid2.short)
-        self.assertEqual('sys3', self.uid3.short)
 
     def test_string(self):
         """Verify UIDs can be converted to string including stamps."""

--- a/doorstop/core/tests/test_types.py
+++ b/doorstop/core/tests/test_types.py
@@ -70,20 +70,47 @@ class TestUID(unittest.TestCase):
         """Verify UIDs are parsed correctly (string)."""
         uid = UID('REQ')
         self.assertRaises(DoorstopError, getattr, uid, 'prefix')
-        uid = UID('REQ-?')
         self.assertRaises(DoorstopError, getattr, uid, 'number')
+        self.assertRaises(DoorstopError, getattr, uid, 'name')
+        uid = UID('REQ-?')
+        self.assertRaises(DoorstopError, getattr, uid, 'prefix')
+        self.assertRaises(DoorstopError, getattr, uid, 'number')
+        self.assertRaises(DoorstopError, getattr, uid, 'name')
 
     def test_init_dict(self):
         """Verify UIDs are parsed correctly (dictionary)."""
         uid = UID({'REQ001': 'abc123'})
         self.assertEqual('REQ', uid.prefix)
         self.assertEqual(1, uid.number)
+        self.assertEqual('', uid.name)
         self.assertEqual('abc123', uid.stamp)
+
+    def test_init_name(self):
+        """Verify UIDs are parsed correctly (name)."""
+        uid = UID('REQ', '-', 'NAME')
+        self.assertEqual('REQ', uid.prefix)
+        self.assertEqual(-1, uid.number)
+        self.assertEqual('NAME', uid.name)
+        uid = UID('REQ-NAME')
+        self.assertEqual('REQ', uid.prefix)
+        self.assertEqual(-1, uid.number)
+        self.assertEqual('NAME', uid.name)
+        uid = UID('REQ-MIDDLE-NAME')
+        self.assertEqual('REQ-MIDDLE', uid.prefix)
+        self.assertEqual(-1, uid.number)
+        self.assertEqual('NAME', uid.name)
+        uid = UID('REQ.A-B_C')
+        self.assertEqual('REQ.A-B', uid.prefix)
+        self.assertEqual(-1, uid.number)
+        self.assertEqual('C', uid.name)
+        uid = UID('REQ.A-B_C more')
+        self.assertEqual('REQ.A-B', uid.prefix)
+        self.assertEqual(-1, uid.number)
+        self.assertEqual('C', uid.name)
 
     def test_init_values(self):
         """Verify UIDs are parsed correctly (values)."""
         self.assertRaises(TypeError, UID, 'REQ', '-')
-        self.assertRaises(TypeError, UID, 'REQ', '-', 42)
         self.assertRaises(TypeError, UID, 'REQ', '-', 42, 3, 'extra')
 
     def test_init_empty(self):
@@ -118,6 +145,19 @@ class TestUID(unittest.TestCase):
         self.assertEqual('req1', UID('REQ001'))
         self.assertNotEqual(None, UID('REQ001'))
         self.assertEqual(self.uid1, self.uid4)
+        self.assertEqual(UID('a', '-', 'b'), UID('a', '-', 'b'))
+        self.assertNotEqual(UID('a', '-', 'b'), UID('a', '-', 'c'))
+
+    def test_le(self):
+        """Verify UID's less operator."""
+        self.assertTrue(UID('a', '-', 1, 0) < UID('a', '-', 2, 0))
+        self.assertFalse(UID('a', '-', 1, 0) < UID('a', '-', 1, 0))
+        self.assertFalse(UID('a', '-', 2, 0) < UID('a', '-', 1, 0))
+        self.assertTrue(UID('a', '-', 'a') < UID('a', '-', 'b'))
+        self.assertFalse(UID('a', '-', 'a') < UID('a', '-', 'a'))
+        self.assertFalse(UID('a', '-', 'b') < UID('a', '-', 'a'))
+        self.assertTrue(UID('a', '-', 'a') < UID('a', '-', 1, 0))
+        self.assertFalse(UID('a', '-', 1, 0) < UID('a', '-', 'a'))
 
     def test_sort(self):
         """Verify UIDs can be sorted."""

--- a/doorstop/core/types.py
+++ b/doorstop/core/types.py
@@ -141,7 +141,10 @@ class UID:
         if not isinstance(other, UID):
             other = UID(other)
         try:
-            return all((self.prefix == other.prefix, self.number == other.number))
+            self.check()
+            other.check()
+            # pylint: disable=protected-access
+            return self._prefix == other._prefix and self._number == other._number
         except DoorstopError:
             return self.value.lower() == other.value.lower()
 
@@ -150,10 +153,13 @@ class UID:
 
     def __lt__(self, other):
         try:
-            if self.prefix == other.prefix:
-                return self.number < other.number
+            self.check()
+            other.check()
+            # pylint: disable=protected-access
+            if self._prefix == other._prefix:
+                return self._number < other._number
             else:
-                return self.prefix < other.prefix
+                return self._prefix < other._prefix
         except DoorstopError:
             return self.value < other.value
 

--- a/doorstop/core/types.py
+++ b/doorstop/core/types.py
@@ -215,14 +215,27 @@ class UID:
         >>> UID.split_uid('REQ2-001')
         (Prefix('REQ2'), 1, '', None)
 
+        >>> UID.split_uid('REQ2-NAME')
+        (Prefix('REQ2'), -1, 'NAME', None)
+
+        >>> UID.split_uid('REQ2-NAME007')
+        (Prefix('REQ2'), -1, 'NAME007', None)
+
+        >>> UID.split_uid('REQ2-123NAME')
+        (Prefix('REQ2'), -1, '123NAME', None)
+
         """
+        m = re.match("([\\w.-]+)[" + settings.SEP_CHARS + "](\\w+)", value)
+        if m:
+            try:
+                num = int(m.group(2))
+                return Prefix(m.group(1)), num, '', None
+            except ValueError:
+                return Prefix(m.group(1)), -1, m.group(2), None
         m = re.match(r"([\w.-]*\D)(\d+)", value)
         if m:
             num = m.group(2)
             return Prefix(m.group(1).rstrip(settings.SEP_CHARS)), int(num), '', None
-        m = re.match("([\\w.-]+)[" + settings.SEP_CHARS + "](\\w+)", value)
-        if m:
-            return Prefix(m.group(1)), -1, m.group(2), None
         return None, None, None, DoorstopError("invalid UID: {}".format(value))
 
     @staticmethod

--- a/doorstop/core/types.py
+++ b/doorstop/core/types.py
@@ -49,11 +49,6 @@ class Prefix(str):
     def __lt__(self, other):
         return self.lower() < other.lower()
 
-    @property
-    def short(self):
-        """Get a shortened version of the prefix."""
-        return self.lower()
-
     @staticmethod
     def load_prefix(value):
         """Convert a value to a prefix.
@@ -173,12 +168,6 @@ class UID:
         """Get the UID's number."""
         self.check()
         return self._number
-
-    @property
-    def short(self):
-        """Get a shortened version of the UID."""
-        self.check()
-        return self.prefix.lower() + str(self.number)
 
     @property
     def string(self):

--- a/doorstop/core/types.py
+++ b/doorstop/core/types.py
@@ -88,6 +88,11 @@ class UID:
         :param *values: prefix, separator, number, digit count
         param stamp: stamp of :class:`~doorstop.core.item.Item` (if known)
 
+        Option 4:
+
+        :param *values: prefix, separator, name
+        param stamp: stamp of :class:`~doorstop.core.item.Item` (if known)
+
         """
         if values and isinstance(values[0], UID):
             self.stamp: Stamp = stamp or values[0].stamp
@@ -109,19 +114,15 @@ class UID:
             else:
                 self.value = str(value) if values[0] else ''
         elif len(values) == 4:
-            self.value = UID.join_uid(*values)  # pylint: disable=no-value-for-parameter
+            # pylint: disable=no-value-for-parameter
+            self.value = UID.join_uid_4(*values)
+        elif len(values) == 3:
+            # pylint: disable=no-value-for-parameter
+            self.value = UID.join_uid_3(*values)
         else:
-            raise TypeError("__init__() takes 1 or 4 positional arguments")
+            raise TypeError("__init__() takes 1, 3, or 4 positional arguments")
         # Split values
-        try:
-            parts = UID.split_uid(self.value)
-            self._prefix = Prefix(parts[0])
-            self._number = parts[1]
-        except ValueError:
-            self._prefix = self._number = None
-            self._exc = DoorstopError("invalid UID: {}".format(self.value))
-        else:
-            self._exc = None
+        self._prefix, self._number, self._name, self._exc = UID.split_uid(self.value)
 
     def __repr__(self):
         if self.stamp:
@@ -133,7 +134,7 @@ class UID:
         return self.value
 
     def __hash__(self):
-        return hash((self._prefix, self._number))
+        return hash((self._prefix, self._number, self._name))
 
     def __eq__(self, other):
         if not other:
@@ -144,7 +145,11 @@ class UID:
             self.check()
             other.check()
             # pylint: disable=protected-access
-            return self._prefix == other._prefix and self._number == other._number
+            return (
+                self._prefix == other._prefix
+                and self._number == other._number
+                and self._name == other._name
+            )
         except DoorstopError:
             return self.value.lower() == other.value.lower()
 
@@ -157,7 +162,10 @@ class UID:
             other.check()
             # pylint: disable=protected-access
             if self._prefix == other._prefix:
-                return self._number < other._number
+                if self._number == other._number:
+                    return self._name < other._name
+                else:
+                    return self._number < other._number
             else:
                 return self._prefix < other._prefix
         except DoorstopError:
@@ -176,6 +184,12 @@ class UID:
         return self._number
 
     @property
+    def name(self):
+        """Get the UID's name."""
+        self.check()
+        return self._name
+
+    @property
     def string(self):
         """Convert the UID and stamp to a single string."""
         if self.stamp:
@@ -189,41 +203,48 @@ class UID:
             raise self._exc  # pylint: disable=raising-bad-type
 
     @staticmethod
-    def split_uid(text):
-        """Split an item's UID string into a prefix and number.
+    def split_uid(value):
+        """Split an item's UID string into a prefix, number, name, and exception.
 
         >>> UID.split_uid('ABC00123')
-        ('ABC', 123)
+        (Prefix('ABC'), 123, '', None)
 
         >>> UID.split_uid('ABC.HLR_01-00123')
-        ('ABC.HLR_01', 123)
+        (Prefix('ABC.HLR_01'), 123, '', None)
 
         >>> UID.split_uid('REQ2-001')
-        ('REQ2', 1)
+        (Prefix('REQ2'), 1, '', None)
 
         """
-        match = re.match(r"([\w.-]*\D)(\d+)", text)
-        if not match:
-            raise ValueError("unable to parse UID: {}".format(text))
-        prefix = match.group(1).rstrip(settings.SEP_CHARS)
-        number = int(match.group(2))
-        return prefix, number
+        m = re.match(r"([\w.-]*\D)(\d+)", value)
+        if m:
+            num = m.group(2)
+            return Prefix(m.group(1).rstrip(settings.SEP_CHARS)), int(num), '', None
+        m = re.match("([\\w.-]+)[" + settings.SEP_CHARS + "](\\w+)", value)
+        if m:
+            return Prefix(m.group(1)), -1, m.group(2), None
+        return None, None, None, DoorstopError("invalid UID: {}".format(value))
 
     @staticmethod
-    def join_uid(prefix, sep, number, digits):
-        """Join the parts of an item's UID into a string.
+    def join_uid_4(prefix, sep, number, digits):
+        """Join the four parts of an item's UID into a string.
 
-        >>> UID.join_uid('ABC', '', 123, 5)
+        >>> UID.join_uid_4('ABC', '', 123, 5)
         'ABC00123'
 
-        >>> UID.join_uid('REQ.H', '-', 42, 4)
+        >>> UID.join_uid_4('REQ.H', '-', 42, 4)
         'REQ.H-0042'
 
-        >>> UID.join_uid('ABC', '-', 123, 0)
+        >>> UID.join_uid_4('ABC', '-', 123, 0)
         'ABC-123'
 
         """
         return "{}{}{}".format(prefix, sep, str(number).zfill(digits))
+
+    @staticmethod
+    def join_uid_3(prefix, sep, name):
+        """Join the three parts of an item's UID into a string."""
+        return "{}{}{}".format(prefix, sep, name)
 
 
 class _Literal(str):

--- a/doorstop/core/validators/item_validator.py
+++ b/doorstop/core/validators/item_validator.py
@@ -121,7 +121,7 @@ class ItemValidator:
             return
 
         # Verify an item's UID matches its document's prefix
-        if item.prefix != document.prefix:
+        if item.uid.prefix != document.prefix:
             msg = "prefix differs from document ({})".format(document.prefix)
             yield DoorstopInfo(msg)
 


### PR DESCRIPTION
Make the item UID a bit more flexible so that it can contain a number or a name part. This enables user-specified names for items, e.g. REQ-ABC.yml. The new command line option can be also used to specify a user provided number, e.g. `doorstop add -n 99 REQ` creates REQ-099.yml.