### PR TITLE
tree: improve "multiple root documents" error message

### DIFF
--- a/doorstop/core/tree.py
+++ b/doorstop/core/tree.py
@@ -70,7 +70,13 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
             for document in list(unplaced):
                 if document.parent is None:
                     log.info("root of the tree: {}".format(document))
-                    raise DoorstopError("multiple root documents")
+                    message = "multiple root documents:\n- {}: {}\n- {}: {}".format(
+                        tree.document.prefix,
+                        tree.document.path,
+                        document.prefix,
+                        document.path,
+                    )
+                    raise DoorstopError(message)
                 try:
                     tree._place(document)  # pylint: disable=W0212
                 except DoorstopError as error:


### PR DESCRIPTION
Addresses #293, #432, #436.

I am open to improving the error message further but this is definitely a step forward.