### PR TITLE
Improve fingerprinting of extended attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 2.1 (future)
+
+- **BREAKING:** The fingerprint calculation method of reviewed extended
+attributes changed.  Use `doorstop review all` followed by `doorstop clear all`
+to update an existing project. WARNING: This marks all items as reviewed and
+clears all suspect links.
+
 # 2.0 (2019-11-29)
 
 - Dropped support for Python 3.5.

--- a/docs/reference/item.md
+++ b/docs/reference/item.md
@@ -381,9 +381,13 @@ attributes:
 ```
 
 If attributes listed in `reviewed` do not exist in an item of this document,
-then a warning is issued by the validation command `doorstop`:
-
-```
-WARNING: REQ001: missing extended reviewed attribute: type
-WARNING: REQ001: missing extended reviewed attribute: verification-method
-```
+then these attributes are skipped in the fingerprint calculation and no warning
+is issued by the validation command `doorstop`.  Validation of items against a
+template should be done by third-party tools.  Changing the order of reviewed
+attributes listed in the document configuration changes the fingerprint of
+existing item of the documents which have these attributes.  Adding new
+reviewed attributes to the document configuration does not change the
+fingerprint of existing items of the document, if they do not have them,
+otherwise the fingerprint changes.  Removing a reviewed attribute from the
+document configuration changes the fingerprint of all items of the document
+with such an attribute.

--- a/doorstop/core/tests/test_item.py
+++ b/doorstop/core/tests/test_item.py
@@ -9,7 +9,7 @@ import unittest
 from typing import List
 from unittest.mock import MagicMock, Mock, patch
 
-from doorstop import common, core
+from doorstop import common
 from doorstop.common import DoorstopError
 from doorstop.core.item import Item, UnknownItem
 from doorstop.core.tests import (
@@ -799,7 +799,17 @@ class TestItem(unittest.TestCase):
         """Verify fingerprint with one extended reviewed attribute."""
         self.item._data['type'] = 'functional'
         self.item.document.extended_reviewed = ['type']
-        stamp = '5ijLUBTXGCkN-2wctQTQ5cl2-ZTDMeukDlXDy0OBCGg='
+        stamp = 'HViLqscmSeVfv2jYBFhXdceTcEWWc0r9uchEmX7xSTY='
+        self.assertEqual(stamp, self.item.stamp())
+        self.item.document.extended_reviewed = []
+        stamp = 'OoHOpBnrt8us7ph8DVnz5KrQs6UBqj_8MEACA0gWpjY='
+        self.assertEqual(stamp, self.item.stamp())
+
+    def test_stamp_with_complex_extended_reviewed(self):
+        """Verify fingerprint with complex extended reviewed attribute."""
+        self.item._data['attr'] = ['a', 'b', ['c', {'d': 'e', 'f': ['g']}]]
+        self.item.document.extended_reviewed = ['attr']
+        stamp = 'H1frEDRLk8y7eaNQPpGbgpKlWLqXc3_QfiCq1qvrUtA='
         self.assertEqual(stamp, self.item.stamp())
 
     def test_stamp_with_two_extended_reviewed(self):
@@ -807,32 +817,43 @@ class TestItem(unittest.TestCase):
         self.item._data['type'] = 'functional'
         self.item._data['verification-method'] = 'test'
         self.item.document.extended_reviewed = ['type', 'verification-method']
-        stamp = 'xmXpN4L0mNHm8-5Ga24VJLc5b9J2ttG4G8XVGrgDFeU='
+        stamp = 'S_yJkuwMTVG70Pcr3R6zdSR1VdviwxVWgG7q5b5NpjU='
         self.assertEqual(stamp, self.item.stamp())
 
-    def test_stamp_with_reversed_extended_reviewed_reverse(self):
+    def test_stamp_with_reversed_extended_reviewed(self):
         """Verify fingerprint with reversed extended reviewed attributes."""
         self.item._data['type'] = 'functional'
         self.item._data['verification-method'] = 'test'
         self.item.document.extended_reviewed = ['verification-method', 'type']
-        stamp = '2HCtrWC2tYEpFpCtNKf-D4n_s0IrxuEuiF-6cZ6wdr0='
+        stamp = 'OhVM3nMW4mensMfWA-VIcbn5XYbxpPI_ZEDVcCjoGo0='
         self.assertEqual(stamp, self.item.stamp())
 
     def test_stamp_with_missing_extended_reviewed_reverse(self):
-        """Verify fingerprint with missing extended reviewed attribute."""
-        with ListLogHandler(core.item.log) as handler:
-            self.item._data['type'] = 'functional'
-            self.item._data['verification-method'] = 'test'
-            self.item.document.extended_reviewed = [
-                'missing',
-                'type',
-                'verification-method',
-            ]
-            stamp = 'xmXpN4L0mNHm8-5Ga24VJLc5b9J2ttG4G8XVGrgDFeU='
-            self.assertEqual(stamp, self.item.stamp())
-            self.assertIn(
-                "RQ001: missing extended reviewed attribute: missing", handler.records
-            )
+        """Verify fingerprint with missing extended reviewed attributes."""
+        self.item._data['type'] = 'functional'
+        self.item._data['verification-method'] = 'test'
+        self.item.document.extended_reviewed = [
+            'missing',
+            'type',
+            'verification-method',
+        ]
+        stamp = 'S_yJkuwMTVG70Pcr3R6zdSR1VdviwxVWgG7q5b5NpjU='
+        self.assertEqual(stamp, self.item.stamp())
+        self.item.document.extended_reviewed = [
+            'missing',
+            'type',
+            'verification-method',
+            'missing-2',
+        ]
+        stamp = 'S_yJkuwMTVG70Pcr3R6zdSR1VdviwxVWgG7q5b5NpjU='
+        self.assertEqual(stamp, self.item.stamp())
+        self.item.document.extended_reviewed = [
+            'type',
+            'verification-method',
+            'missing-2',
+        ]
+        stamp = 'S_yJkuwMTVG70Pcr3R6zdSR1VdviwxVWgG7q5b5NpjU='
+        self.assertEqual(stamp, self.item.stamp())
 
     def test_stamp_links(self):
         """Verify an item's contents can be stamped."""


### PR DESCRIPTION
Do not issue a warning in case a reviewed attribute is missing.  The
doorstop tool has not enough information to do a proper validation of
items of extended attributes.

Make the value serialization independent of the YAML file format.  Use a
simple serialization based on Python string representations.  This helps
in case the item storage format changes in the future.

This is a breaking change, since the fingerprint of existing items may
change.