### PR TITLE
Fix fingerprint of reviewed extended attributes

### DIFF
--- a/docs/reference/item.md
+++ b/docs/reference/item.md
@@ -390,4 +390,5 @@ reviewed attributes to the document configuration does not change the
 fingerprint of existing items of the document, if they do not have them,
 otherwise the fingerprint changes.  Removing a reviewed attribute from the
 document configuration changes the fingerprint of all items of the document
-with such an attribute.
+with such an attribute.  Empty strings, lists, and dictionaries affect the
+fingerprint.

--- a/docs/reference/item.md
+++ b/docs/reference/item.md
@@ -390,5 +390,5 @@ reviewed attributes to the document configuration does not change the
 fingerprint of existing items of the document, if they do not have them,
 otherwise the fingerprint changes.  Removing a reviewed attribute from the
 document configuration changes the fingerprint of all items of the document
-with such an attribute.  Empty strings, lists, and dictionaries affect the
-fingerprint.
+with such an attribute.  The type of the values, empty strings, lists, and
+dictionaries affect the fingerprint.

--- a/doorstop/core/item.py
+++ b/doorstop/core/item.py
@@ -65,14 +65,16 @@ def _convert_to_str(value, result):
     :return: the updated result of the string serialization
     """
     if isinstance(value, list):
+        result += "\\L"
         for v in value:
             result = _convert_to_str(v, result)
         return result
     if isinstance(value, dict):
+        result += "\\D"
         for k in sorted(value.keys()):
             result = _convert_to_str(value[k], result)
         return result
-    return result + str(value)
+    return result + "\\V" + str(value).replace("\\", "\\\\")
 
 
 def requires_tree(func):
@@ -761,7 +763,8 @@ class Item(BaseFileObject):  # pylint: disable=R0902
         if links:
             values.extend(self.links)
         for key in self.document.extended_reviewed:
-            values.append(_convert_to_str(self._data.get(key, ""), ""))
+            if key in self._data:
+                values.append(_convert_to_str(self._data[key], ""))
         return Stamp(*values)
 
     @auto_save

--- a/doorstop/core/item.py
+++ b/doorstop/core/item.py
@@ -57,7 +57,8 @@ def _convert_to_str(value, result):
 
     This function is independent of the YAML format and may be used for data
     which should be independent of the actual item storage format.  It depends
-    only on the Python sorting function and string representation.
+    only on the Python sorting function, type information, and string
+    representation.
 
     :param value: the value to convert
     :param result: the current result of the string serialization
@@ -74,7 +75,7 @@ def _convert_to_str(value, result):
         for k in sorted(value.keys()):
             result = _convert_to_str(value[k], result)
         return result
-    return result + "\\V" + str(value).replace("\\", "\\\\")
+    return result + "\\T" + str(type(value)) + "\\V" + str(value).replace("\\", "\\\\")
 
 
 def requires_tree(func):

--- a/doorstop/core/tests/test_item.py
+++ b/doorstop/core/tests/test_item.py
@@ -799,7 +799,7 @@ class TestItem(unittest.TestCase):
         """Verify fingerprint with one extended reviewed attribute."""
         self.item._data['type'] = 'functional'
         self.item.document.extended_reviewed = ['type']
-        stamp = 'HViLqscmSeVfv2jYBFhXdceTcEWWc0r9uchEmX7xSTY='
+        stamp = '0DXIA1m0z7JFM0DXP2AD0RvvtWjJCmkt7wJkL_3eIEE='
         self.assertEqual(stamp, self.item.stamp())
         self.item.document.extended_reviewed = []
         stamp = 'OoHOpBnrt8us7ph8DVnz5KrQs6UBqj_8MEACA0gWpjY='
@@ -807,9 +807,39 @@ class TestItem(unittest.TestCase):
 
     def test_stamp_with_complex_extended_reviewed(self):
         """Verify fingerprint with complex extended reviewed attribute."""
-        self.item._data['attr'] = ['a', 'b', ['c', {'d': 'e', 'f': ['g']}]]
         self.item.document.extended_reviewed = ['attr']
-        stamp = 'H1frEDRLk8y7eaNQPpGbgpKlWLqXc3_QfiCq1qvrUtA='
+        self.item._data['attr'] = ['a', 'b', ['c', {'d': 'e', 'f': ['g']}]]
+        stamp = '8SgFOmxh98JO5QalGy6ZV33rfQUmSz66l97141rUfDk='
+        self.assertEqual(stamp, self.item.stamp())
+
+    def test_stamp_with_empty_string_extended_reviewed(self):
+        """Verify fingerprint with empty string extended reviewed attribute."""
+        self.item.document.extended_reviewed = ['attr']
+        self.item._data['attr'] = ''
+        stamp = 'UJUqtonwnALvu9nQr2pP3f5fw_xLQf62oY2SQRoAxbI='
+        self.assertEqual(stamp, self.item.stamp())
+
+    def test_stamp_with_list_extended_reviewed(self):
+        """Verify fingerprint with list extended reviewed attributes."""
+        self.item.document.extended_reviewed = ['attr']
+        self.item._data['attr'] = []
+        stamp = 'qwUP7VgUbHWIdj-T2ZfGhROfJQwSHDhsC6WR9vUTk1U='
+        self.assertEqual(stamp, self.item.stamp())
+        self.item._data['attr'] = ['']
+        stamp = 'JnRCBW63NQa6D_oQljqrPisAillBC3DrMx7_UdYO56A='
+        self.assertEqual(stamp, self.item.stamp())
+        self.item._data['attr'] = [[]]
+        stamp = 'AXWIEp9CYI4UWzIw4NinvDrUFzQl_8rCL9B_PmGisYk='
+        self.assertEqual(stamp, self.item.stamp())
+        self.item._data['attr'] = [{}]
+        stamp = 'C5Bm5ej09zaJxbtbE9PIcno8M9lIBIC6sJOmNJkrJH8='
+        self.assertEqual(stamp, self.item.stamp())
+
+    def test_stamp_with_empty_dict_extended_reviewed(self):
+        """Verify fingerprint with empty dict extended reviewed attribute."""
+        self.item.document.extended_reviewed = ['attr']
+        self.item._data['attr'] = {}
+        stamp = '5Yv0vWG2h5rAQt_1LujZuD9X6udWO52KVaSA5SJ3Emc='
         self.assertEqual(stamp, self.item.stamp())
 
     def test_stamp_with_two_extended_reviewed(self):
@@ -817,7 +847,7 @@ class TestItem(unittest.TestCase):
         self.item._data['type'] = 'functional'
         self.item._data['verification-method'] = 'test'
         self.item.document.extended_reviewed = ['type', 'verification-method']
-        stamp = 'S_yJkuwMTVG70Pcr3R6zdSR1VdviwxVWgG7q5b5NpjU='
+        stamp = '9K2qfSINvLZWY5059szwe3wxDQUzdYz0nkMAx8khIPk='
         self.assertEqual(stamp, self.item.stamp())
 
     def test_stamp_with_reversed_extended_reviewed(self):
@@ -825,7 +855,7 @@ class TestItem(unittest.TestCase):
         self.item._data['type'] = 'functional'
         self.item._data['verification-method'] = 'test'
         self.item.document.extended_reviewed = ['verification-method', 'type']
-        stamp = 'OhVM3nMW4mensMfWA-VIcbn5XYbxpPI_ZEDVcCjoGo0='
+        stamp = 'HwTCwp5cUlRQ9yKjuTnUU3YbA79ZKVBv0n1sxH5E35s='
         self.assertEqual(stamp, self.item.stamp())
 
     def test_stamp_with_missing_extended_reviewed_reverse(self):
@@ -837,7 +867,7 @@ class TestItem(unittest.TestCase):
             'type',
             'verification-method',
         ]
-        stamp = 'S_yJkuwMTVG70Pcr3R6zdSR1VdviwxVWgG7q5b5NpjU='
+        stamp = '9K2qfSINvLZWY5059szwe3wxDQUzdYz0nkMAx8khIPk='
         self.assertEqual(stamp, self.item.stamp())
         self.item.document.extended_reviewed = [
             'missing',
@@ -845,14 +875,14 @@ class TestItem(unittest.TestCase):
             'verification-method',
             'missing-2',
         ]
-        stamp = 'S_yJkuwMTVG70Pcr3R6zdSR1VdviwxVWgG7q5b5NpjU='
+        stamp = '9K2qfSINvLZWY5059szwe3wxDQUzdYz0nkMAx8khIPk='
         self.assertEqual(stamp, self.item.stamp())
         self.item.document.extended_reviewed = [
             'type',
             'verification-method',
             'missing-2',
         ]
-        stamp = 'S_yJkuwMTVG70Pcr3R6zdSR1VdviwxVWgG7q5b5NpjU='
+        stamp = '9K2qfSINvLZWY5059szwe3wxDQUzdYz0nkMAx8khIPk='
         self.assertEqual(stamp, self.item.stamp())
 
     def test_stamp_links(self):

--- a/doorstop/core/tests/test_item.py
+++ b/doorstop/core/tests/test_item.py
@@ -799,7 +799,7 @@ class TestItem(unittest.TestCase):
         """Verify fingerprint with one extended reviewed attribute."""
         self.item._data['type'] = 'functional'
         self.item.document.extended_reviewed = ['type']
-        stamp = '0DXIA1m0z7JFM0DXP2AD0RvvtWjJCmkt7wJkL_3eIEE='
+        stamp = 'MmcvtzB20PHv0IBhxpNtpZCa0CfYwHnPr3Jk8W-TRxk='
         self.assertEqual(stamp, self.item.stamp())
         self.item.document.extended_reviewed = []
         stamp = 'OoHOpBnrt8us7ph8DVnz5KrQs6UBqj_8MEACA0gWpjY='
@@ -809,14 +809,31 @@ class TestItem(unittest.TestCase):
         """Verify fingerprint with complex extended reviewed attribute."""
         self.item.document.extended_reviewed = ['attr']
         self.item._data['attr'] = ['a', 'b', ['c', {'d': 'e', 'f': ['g']}]]
-        stamp = '8SgFOmxh98JO5QalGy6ZV33rfQUmSz66l97141rUfDk='
+        stamp = 'JcCRKBgLLTOatY8OpAMabblP7Mu24JZRn3WgoXwjmSk='
+        self.assertEqual(stamp, self.item.stamp())
+
+    def test_stamp_with_none_extended_reviewed(self):
+        """Verify fingerprint with None extended reviewed attribute."""
+        self.item.document.extended_reviewed = ['attr']
+        self.item._data['attr'] = None
+        stamp = 'e0qDli7ZJwhf161b_v7AdGNNl7xHx-bs28aFFk7aqT4='
+        self.assertEqual(stamp, self.item.stamp())
+
+    def test_stamp_with_value_one_extended_reviewed(self):
+        """Verify fingerprint with value one extended reviewed attribute."""
+        self.item.document.extended_reviewed = ['attr']
+        self.item._data['attr'] = 1
+        stamp = '0s4QQh2AZXSoZNYGcfybCGLHAgO4EWY9gxK_LVNiqOA='
+        self.assertEqual(stamp, self.item.stamp())
+        self.item._data['attr'] = '1'
+        stamp = 'GWlkpsRSzT_lgE4CNvE4wrUZZwM3iHKHOa6idcHUSUw='
         self.assertEqual(stamp, self.item.stamp())
 
     def test_stamp_with_empty_string_extended_reviewed(self):
         """Verify fingerprint with empty string extended reviewed attribute."""
         self.item.document.extended_reviewed = ['attr']
         self.item._data['attr'] = ''
-        stamp = 'UJUqtonwnALvu9nQr2pP3f5fw_xLQf62oY2SQRoAxbI='
+        stamp = 'H70VgWPTH89Q9KfIJBfeilC7-wYAtWigxZ2iUcZ9j-8='
         self.assertEqual(stamp, self.item.stamp())
 
     def test_stamp_with_list_extended_reviewed(self):
@@ -825,8 +842,11 @@ class TestItem(unittest.TestCase):
         self.item._data['attr'] = []
         stamp = 'qwUP7VgUbHWIdj-T2ZfGhROfJQwSHDhsC6WR9vUTk1U='
         self.assertEqual(stamp, self.item.stamp())
+        self.item._data['attr'] = [None]
+        stamp = 'GHDRiY4C3twnXDTCqoCAD_iymfe892ZzQuYjuccFBT0='
+        self.assertEqual(stamp, self.item.stamp())
         self.item._data['attr'] = ['']
-        stamp = 'JnRCBW63NQa6D_oQljqrPisAillBC3DrMx7_UdYO56A='
+        stamp = 'Rfwtl2j56CdQLtE4b5StEa0ECVTqlOpABLdhEa1avyo='
         self.assertEqual(stamp, self.item.stamp())
         self.item._data['attr'] = [[]]
         stamp = 'AXWIEp9CYI4UWzIw4NinvDrUFzQl_8rCL9B_PmGisYk='
@@ -847,7 +867,7 @@ class TestItem(unittest.TestCase):
         self.item._data['type'] = 'functional'
         self.item._data['verification-method'] = 'test'
         self.item.document.extended_reviewed = ['type', 'verification-method']
-        stamp = '9K2qfSINvLZWY5059szwe3wxDQUzdYz0nkMAx8khIPk='
+        stamp = 'TF_q0ofVwjaJI1RYu9jtDeSCm5gAQWIqsxpPxAW5D64='
         self.assertEqual(stamp, self.item.stamp())
 
     def test_stamp_with_reversed_extended_reviewed(self):
@@ -855,7 +875,7 @@ class TestItem(unittest.TestCase):
         self.item._data['type'] = 'functional'
         self.item._data['verification-method'] = 'test'
         self.item.document.extended_reviewed = ['verification-method', 'type']
-        stamp = 'HwTCwp5cUlRQ9yKjuTnUU3YbA79ZKVBv0n1sxH5E35s='
+        stamp = 'dMWAazlLoeZSwlD87nEwQtAFq32WQuX_Bd_8kehaKJg='
         self.assertEqual(stamp, self.item.stamp())
 
     def test_stamp_with_missing_extended_reviewed_reverse(self):
@@ -867,7 +887,7 @@ class TestItem(unittest.TestCase):
             'type',
             'verification-method',
         ]
-        stamp = '9K2qfSINvLZWY5059szwe3wxDQUzdYz0nkMAx8khIPk='
+        stamp = 'TF_q0ofVwjaJI1RYu9jtDeSCm5gAQWIqsxpPxAW5D64='
         self.assertEqual(stamp, self.item.stamp())
         self.item.document.extended_reviewed = [
             'missing',
@@ -875,14 +895,14 @@ class TestItem(unittest.TestCase):
             'verification-method',
             'missing-2',
         ]
-        stamp = '9K2qfSINvLZWY5059szwe3wxDQUzdYz0nkMAx8khIPk='
+        stamp = 'TF_q0ofVwjaJI1RYu9jtDeSCm5gAQWIqsxpPxAW5D64='
         self.assertEqual(stamp, self.item.stamp())
         self.item.document.extended_reviewed = [
             'type',
             'verification-method',
             'missing-2',
         ]
-        stamp = '9K2qfSINvLZWY5059szwe3wxDQUzdYz0nkMAx8khIPk='
+        stamp = 'TF_q0ofVwjaJI1RYu9jtDeSCm5gAQWIqsxpPxAW5D64='
         self.assertEqual(stamp, self.item.stamp())
 
     def test_stamp_links(self):


### PR DESCRIPTION
The _convert_to_str() function did not take empty strings, list, and
dictionaries into account.  Use an escape character to encode the type
of a sub-value.

This is again a breaking change which alters the value of existing
fingerprints.