### PR TITLE
Make reference file detection under windows work with linux-created requirements

### DIFF
--- a/doorstop/core/reference_finder.py
+++ b/doorstop/core/reference_finder.py
@@ -70,7 +70,7 @@ class ReferenceFinder:
         """
 
         log.debug("searching for ref '{}'...".format(ref_path))
-        ref_full_path = os.path.join(root, ref_path)
+        ref_full_path = os.path.normpath(os.path.join(root, ref_path))
 
         for path, filename, relpath in tree.vcs.paths:
             # Skip the item's file while searching

--- a/doorstop/core/tests/test_item.py
+++ b/doorstop/core/tests/test_item.py
@@ -633,11 +633,11 @@ class TestItem(unittest.TestCase):
         self.assertEqual(2, len(ref))
 
         relpath_1, keyword_line_1 = ref[0]
-        self.assertEqual(relpath_1, 'files/REQ001.yml')
+        self.assertEqual(relpath_1, os.path.join('files', 'REQ001.yml'))
         self.assertEqual(keyword_line_1, None)
 
         relpath_2, keyword_line_2 = ref[1]
-        self.assertEqual(relpath_2, 'files/REQ002.yml')
+        self.assertEqual(relpath_2, os.path.join('files', 'REQ002.yml'))
         self.assertEqual(keyword_line_2, None)
 
     @patch('doorstop.settings.CACHE_PATHS', False)
@@ -657,7 +657,7 @@ class TestItem(unittest.TestCase):
         self.assertEqual(1, len(ref))
 
         ref_path, ref_keyword_line = ref[0]
-        self.assertEqual(ref_path, 'files/REQ001.yml')
+        self.assertEqual(ref_path, os.path.join('files', 'REQ001.yml'))
         self.assertEqual(ref_keyword_line, 12)
 
     @patch('doorstop.settings.CACHE_PATHS', False)

--- a/doorstop/core/tests/test_reference_finder.py
+++ b/doorstop/core/tests/test_reference_finder.py
@@ -35,7 +35,7 @@ class TestReferenceFinder(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(path, 'files/REQ001.yml')
+        self.assertEqual(path, os.path.join('files', 'REQ001.yml'))
         self.assertEqual(line, None)
 
     def test_find_file_reference_with_keyword(self):
@@ -53,7 +53,7 @@ class TestReferenceFinder(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(path, 'files/REQ006.yml')
+        self.assertEqual(path, os.path.join('files', 'REQ006.yml'))
         self.assertEqual(line, 10)
 
     def test_find_file_reference_should_skip_item_path(self):
@@ -86,7 +86,7 @@ class TestReferenceFinder(unittest.TestCase):
         )
 
         # Assert
-        self.assertEqual(path, 'files/REQ001.yml')
+        self.assertEqual(path, os.path.join('files', 'REQ001.yml'))
         self.assertEqual(line, 12)
 
     def test_find_file_reference_invalid_keyword_given(self):


### PR DESCRIPTION
Add os.join.normpath in ReferenceFinder to make reference detection of linux-created requirements possible under windows.