### PR TITLE
Adding --traverse-namespace to nosetests for compatibility with Pytho…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ endif
 
 RANDOM_SEED ?= $(shell date +%s)
 
-NOSE_OPTIONS := --with-doctest
+NOSE_OPTIONS := --with-doctest --traverse-namespace
 ifndef DISABLE_COVERAGE
 NOSE_OPTIONS += --with-cov --cov=$(PACKAGE) --cov-report=html --cov-report=term-missing
 endif


### PR DESCRIPTION
…n 3.8

See #459 for details.