### PR TITLE
Fix failing Windows tests

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,8 @@
 environment:
   global:
     RANDOM_SEED: 0
+    PYTHONUTF8: 1
+    VIRTUALENV_PYTHONUTF8: 1
   matrix:
     - PYTHON_MAJOR: 3
       PYTHON_MINOR: 6
@@ -21,6 +23,7 @@ install:
   # Install system dependencies
   - curl -sSL https://raw.githubusercontent.com/sdispater/poetry/master/get-poetry.py | python
   - set PATH=%USERPROFILE%\.poetry\bin;%PATH%
+  - echo "Python UTF8 = %PYTHONUTF8%"
   - make doctor
   # Install project dependencies
   - make install

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,8 @@ $ make install
 
 ## Manual
 
-Run the tests:
+Run the tests:  
+On Windows, ensure that the environment variable PYTHONUTF8=1 is set.
 
 ```sh
 $ make test

--- a/doorstop/core/vcs/tests/test_base.py
+++ b/doorstop/core/vcs/tests/test_base.py
@@ -2,6 +2,7 @@
 
 """Unit tests for the doorstop.vcs.base module."""
 
+import os
 import unittest
 from unittest.mock import patch
 
@@ -51,5 +52,5 @@ class TestSampleWorkingCopy(unittest.TestCase):
         """Verify that paths are cached correctly."""
         wc = SampleWorkingCopy(ROOT)
         paths = [relpath for path, _, relpath in wc.paths]
-        self.assertEqual([], [x for x in paths if x.startswith('.git/')])
-        self.assertNotEqual([], [x for x in paths if x.startswith('doorstop/')])
+        self.assertEqual([], [x for x in paths if x.startswith('.git{}'.format(os.sep))])
+        self.assertNotEqual([], [x for x in paths if x.startswith('doorstop{}'.format(os.sep))])

--- a/doorstop/core/vcs/tests/test_base.py
+++ b/doorstop/core/vcs/tests/test_base.py
@@ -52,5 +52,9 @@ class TestSampleWorkingCopy(unittest.TestCase):
         """Verify that paths are cached correctly."""
         wc = SampleWorkingCopy(ROOT)
         paths = [relpath for path, _, relpath in wc.paths]
-        self.assertEqual([], [x for x in paths if x.startswith('.git{}'.format(os.sep))])
-        self.assertNotEqual([], [x for x in paths if x.startswith('doorstop{}'.format(os.sep))])
+        self.assertEqual(
+            [], [x for x in paths if x.startswith('.git{}'.format(os.sep))]
+        )
+        self.assertNotEqual(
+            [], [x for x in paths if x.startswith('doorstop{}'.format(os.sep))]
+        )


### PR DESCRIPTION
As @bfueldner states in #452, the 6 tests failing on Windows are related to Windows file encoding. Setting the environment variable PYTHONUTF8=1 fixes the issue and all tests pass. His previous PR was failing CI due to a failing "make check". I committed the auto-format update in order to pass the "make check". Assuming @bfueldner updated the appveyor.yml file correctly, the Windows CI should pass. I also updated CONTRIBUTING.md to add a note that Windows users should set the PYTHONUTF8 environment variable appropriately. 

I have a thought, python allows the command line option "-X utf8" as an alternative to using the PYTHONUTF8 environment variable. This might be preferable if we don't want developers to have to set environment variables to run the tests. I'm not familiar enough with nose to know if it's possible to pass python command line parameters when the tests are run or not. If it is, I'd prefer that approach.