### PR TITLE
Fixing Windows Tests

### DIFF
--- a/doorstop/cli/tests/tutorial.py
+++ b/doorstop/cli/tests/tutorial.py
@@ -238,10 +238,15 @@ class TestSection1(TestBase):
 
         cp = self.doorstop("publish REQ", stdout=subprocess.PIPE)
         self.assertIn(
-            b'1.0     REQ001' + str.encode(os.linesep) + str.encode(os.linesep) + 
-b'        Some text' + str.encode(os.linesep) +
-b'        with more than' + str.encode(os.linesep) +
-b'        one line.' + str.encode(os.linesep),
+            b'1.0     REQ001'
+            + str.encode(os.linesep)
+            + str.encode(os.linesep)
+            + b'        Some text'
+            + str.encode(os.linesep)
+            + b'        with more than'
+            + str.encode(os.linesep)
+            + b'        one line.'
+            + str.encode(os.linesep),
             cp.stdout,
         )
 
@@ -264,10 +269,16 @@ b'        one line.' + str.encode(os.linesep),
 
         cp = self.doorstop("publish REQ", stdout=subprocess.PIPE)
         self.assertIn(
-            b'1.0     REQ-ABC' + str.encode(os.linesep) + str.encode(os.linesep) +
-b'1.1     REQ-009' + str.encode(os.linesep) + str.encode(os.linesep) +
-b'1.2     REQ-XYZ' + str.encode(os.linesep) + str.encode(os.linesep) +
-b'1.3     REQ-099',
+            b'1.0     REQ-ABC'
+            + str.encode(os.linesep)
+            + str.encode(os.linesep)
+            + b'1.1     REQ-009'
+            + str.encode(os.linesep)
+            + str.encode(os.linesep)
+            + b'1.2     REQ-XYZ'
+            + str.encode(os.linesep)
+            + str.encode(os.linesep)
+            + b'1.3     REQ-099',
             cp.stdout,
         )
 

--- a/doorstop/cli/tests/tutorial.py
+++ b/doorstop/cli/tests/tutorial.py
@@ -238,12 +238,10 @@ class TestSection1(TestBase):
 
         cp = self.doorstop("publish REQ", stdout=subprocess.PIPE)
         self.assertIn(
-            b'''1.0     REQ001
-
-        Some text
-        with more than
-        one line.
-''',
+            b'1.0     REQ001' + str.encode(os.linesep) + str.encode(os.linesep) + 
+b'        Some text' + str.encode(os.linesep) +
+b'        with more than' + str.encode(os.linesep) +
+b'        one line.' + str.encode(os.linesep),
             cp.stdout,
         )
 
@@ -266,14 +264,10 @@ class TestSection1(TestBase):
 
         cp = self.doorstop("publish REQ", stdout=subprocess.PIPE)
         self.assertIn(
-            b'''1.0     REQ-ABC
-
-1.1     REQ-009
-
-1.2     REQ-XYZ
-
-1.3     REQ-099
-''',
+            b'1.0     REQ-ABC' + str.encode(os.linesep) + str.encode(os.linesep) +
+b'1.1     REQ-009' + str.encode(os.linesep) + str.encode(os.linesep) +
+b'1.2     REQ-XYZ' + str.encode(os.linesep) + str.encode(os.linesep) +
+b'1.3     REQ-099',
             cp.stdout,
         )
 

--- a/doorstop/common.py
+++ b/doorstop/common.py
@@ -111,7 +111,7 @@ def read_text(path):
     """
     log.trace("reading text from '{}'...".format(path))  # type: ignore
     try:
-        with open(path, 'r') as f:
+        with open(path, 'r', encoding='utf-8') as f:
             return f.read()
     except Exception as e:
         msg = "reading '{}' failed: {}".format(path, e)
@@ -172,7 +172,7 @@ def write_text(text, path):
     """
     if text:
         log.trace("writing text to '{}'...".format(path))  # type: ignore
-    with open(path, 'w') as f:
+    with open(path, 'w', encoding='utf-8') as f:
         f.write(text)
     return path
 

--- a/doorstop/core/vcs/tests/test_base.py
+++ b/doorstop/core/vcs/tests/test_base.py
@@ -2,6 +2,7 @@
 
 """Unit tests for the doorstop.vcs.base module."""
 
+import os
 import unittest
 from unittest.mock import patch
 
@@ -52,4 +53,6 @@ class TestSampleWorkingCopy(unittest.TestCase):
         wc = SampleWorkingCopy(ROOT)
         paths = [relpath for path, _, relpath in wc.paths]
         self.assertEqual([], [x for x in paths if x.startswith('.git/')])
-        self.assertNotEqual([], [x for x in paths if x.startswith('doorstop/')])
+        self.assertNotEqual(
+            [], [x for x in paths if x.startswith(os.path.join('doorstop', ''))]
+        )


### PR DESCRIPTION
The fix proposed in #462 utilized the PYTHONUTF8 environment variable to set the system locale to UTF-8. This approach worked for Python 3.7 and 3.8 on Windows, but PYTHONUTF8 is not supported in Python 3.6. @jacebrowning suggested that we remove 3.6 from the Windows build matrix until we find a solution. 

The above got me thinking. It's clear from the unit tests that the intent is for doorstop to support utf-8, regardless of the system's locale. Given that, I'm not sure that setting PYTHONUTF8 is the appropriate solution. It's also a cumbersome restriction to put on users of the tool. Rather than rely on an environment variable, I decided to track down the source of these failures within the doorstop code. It turns out that a simple update to the read_text and write_text function to specify `encoding=utf-8` in common.py fixes the failing Windows tests.

In addition to the above change, I corrected a separate test whose expected text was relying on unix pathing (Afterwards I realized that this is the same fix that @bfueldner made in #456). I also made some changes to the expected text in tutorial.py (integration tests) to get those passing on Windows as well. It needed to use os.linesep rather than relying on newline characters.

I did a `make test` and `make demo` locally on the following platforms with a passing result:
Windows 10, Python 3.6
Windows 10, Python 3.7
Windows 10, Python 3.8
Ubuntu 18.04 (via WSL), Python 3.8

I'm hopeful that all CI tests are in the green in this PR.

I'm definitely not an expert in the complications of file encodings across platforms using python. I'm open to discussing potential issues with this proposed approach if someone has more experience. If this PR is accepted, we can close #462 and #456.