### PR TITLE
Add unique document name check for doorstop create

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,10 +176,14 @@ $(DIST_FILES): $(MODULES) pyproject.toml
 exe: install $(EXE_FILES)
 $(EXE_FILES): $(MODULES) $(PROJECT).spec
 	# For framework/shared support: https://github.com/yyuu/pyenv/wiki
-	poetry run pyinstaller $(PROJECT).spec --noconfirm --clean
+	poetry run pyinstaller doorstop.spec        --noconfirm --clean
+	poetry run pyinstaller doorstop-gui.spec    --noconfirm --clean
+	poetry run pyinstaller doorstop-server.spec --noconfirm --clean
 
 $(PROJECT).spec:
-	poetry run pyi-makespec $(PACKAGE)/__main__.py --onefile --windowed --name=$(PROJECT)
+	poetry run pyi-makespec doorstop/cli/main.py    --onefile --windowed --name=doorstop
+	poetry run pyi-makespec doorstop/gui/main.py    --onefile --windowed --name=doorstop-gui
+	poetry run pyi-makespec doorstop/server/main.py --onefile --windowed --name=doorstop-server
 
 # RELEASE #####################################################################
 

--- a/doorstop/cli/tests/test_all.py
+++ b/doorstop/cli/tests/test_all.py
@@ -99,6 +99,10 @@ class TestCreate(TempTestCase):
         """Verify 'doorstop create' returns an error with a reserved prefix."""
         self.assertRaises(SystemExit, main, ['create', 'ALL', self.temp, '-p', 'REQ'])
 
+    def test_create_error_duplicate_name(self):
+        """Verify 'doorstop create' returns an error with an already existing document name."""
+        self.assertRaises(SystemExit, main, ['create', 'TUT', self.temp, '-p', 'REQ'])
+
 
 @unittest.skipUnless(os.getenv(ENV), REASON)
 class TestDelete(MockTestCase):

--- a/doorstop/core/tree.py
+++ b/doorstop/core/tree.py
@@ -215,6 +215,14 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
 
         """
         prefix = Prefix(value)
+
+        # Check if a document with the same name already exists in the tree.
+        for d in self.documents:
+            if d.prefix == value:
+                raise DoorstopError(
+                    "The document name is already in use ({}).".format(d.path)
+                )
+
         document = Document.new(
             self, path, self.root, prefix, sep=sep, digits=digits, parent=parent
         )


### PR DESCRIPTION
The doorstop create command now checks if the specified document name
is unique within the document tree and ends with an error message
if a document with the specified name already exists.