### PR TITLE
add machine readable traceability matrix

### DIFF
--- a/doorstop/common.py
+++ b/doorstop/common.py
@@ -3,6 +3,7 @@
 """Common exceptions, classes, and functions for Doorstop."""
 
 import argparse
+import csv
 import glob
 import logging
 import os
@@ -174,6 +175,26 @@ def write_text(text, path):
         log.trace("writing text to '{}'...".format(path))  # type: ignore
     with open(path, 'w', encoding='utf-8') as f:
         f.write(text)
+    return path
+
+
+def write_csv(table, path, delimiter=',', newline='', encoding='utf-8'):
+    """Write table to a file.
+
+    :param table: iterator of rows
+    :param path: file to write lines
+    :param delimiter: string to end cells
+    :param newline: string to end lines
+    :param encoding: output file encoding
+
+    :return: path of new file
+
+    """
+    log.trace("writing table to '{}'...".format(path))  # type: ignore
+    with open(path, 'w', newline=newline, encoding=encoding) as stream:
+        writer = csv.writer(stream, delimiter=delimiter)
+        for row in table:
+            writer.writerow(row)
     return path
 
 

--- a/doorstop/core/exporter.py
+++ b/doorstop/core/exporter.py
@@ -2,7 +2,6 @@
 
 """Functions to export documents and items."""
 
-import csv
 import datetime
 import os
 from collections import defaultdict
@@ -216,11 +215,13 @@ def _file_csv(obj, path, delimiter=',', auto=False):
     :return: path of created file
 
     """
-    with open(path, 'w', newline='', encoding='utf-8') as stream:
-        writer = csv.writer(stream, delimiter=delimiter)
-        for row in _tabulate(obj, auto=auto):
-            writer.writerow(row)
-    return path
+    return common.write_csv(
+        _tabulate(obj, auto=auto),
+        path,
+        delimiter=delimiter,
+        newline='',
+        encoding='utf-8',
+    )
 
 
 def _file_tsv(obj, path, auto=False):


### PR DESCRIPTION
In order to enable downstream tooling this creates the same table as in the html index file in a form that can be accessed externally.

When doing a:
```bash
doorstop publish all ./dist/
```

It produces a file called `traceability.csv` by default in addition to the `index.html` file.
This is the _minimal_ feature, it should be possible to add more rich functionality later.