### PR TITLE
Validate external references as well as refs

### DIFF
--- a/.verchew.ini
+++ b/.verchew.ini
@@ -6,7 +6,7 @@ version = GNU Make
 [Python]
 
 cli = python
-version = 3.6 || 3.7 || 3.8
+version = 3.6 || 3.7 || 3.8 || 3.9
 
 [Poetry]
 

--- a/doorstop/core/tests/files/subfolder/REQ005.yml
+++ b/doorstop/core/tests/files/subfolder/REQ005.yml
@@ -6,4 +6,4 @@ normative: true
 ref: ''
 reviewed: null
 text: |
-  An inative requirement.
+  An inactive requirement.

--- a/doorstop/core/tests/test_item_validator.py
+++ b/doorstop/core/tests/test_item_validator.py
@@ -43,7 +43,7 @@ class TestItemValidator(unittest.TestCase):
         self.item_validator = MockItemValidator()
 
     def test_validate_invalid_ref(self):
-        """Verify an invalid reference fails validity."""
+        """Verify an invalid ref fails validity."""
         with patch(
             'doorstop.core.item.Item.find_ref',
             Mock(side_effect=DoorstopError("test invalid ref")),
@@ -51,6 +51,19 @@ class TestItemValidator(unittest.TestCase):
             with ListLogHandler(core.validators.item_validator.log) as handler:
                 self.assertFalse(self.item_validator.validate(self.item))
                 self.assertIn("test invalid ref", handler.records)
+
+    def test_validate_invalid_references(self):
+        """Verify an invalid reference fails validity."""
+        self.item.document = MockSimpleDocument()
+        self.item._data["references"] = [{"path": "invalid", "type": "file"}]
+        self.item_validator = MockItemValidator()
+        with patch(
+            'doorstop.core.item.Item.find_references',
+            Mock(side_effect=DoorstopError("test invalid reference")),
+        ):
+            with ListLogHandler(core.validators.item_validator.log) as handler:
+                self.assertFalse(self.item_validator.validate(self.item))
+                self.assertIn("test invalid reference", handler.records)
 
     def test_validate_inactive(self):
         """Verify an inactive item is not checked."""

--- a/doorstop/core/validators/item_validator.py
+++ b/doorstop/core/validators/item_validator.py
@@ -74,10 +74,11 @@ class ItemValidator:
         if not item.text:
             yield DoorstopWarning("no text")
 
-        # Check external references
+        # Check external refs and references
         if settings.CHECK_REF:
             try:
                 item.find_ref()
+                item.find_references()
             except DoorstopError as exc:
                 yield exc
 


### PR DESCRIPTION
Currently, only the `ref` of an item is validated, while the array of external references is not when running `doorstop. Publishing a document however with non-valid references raises a DoorstopError.

Here is a fix for checking references when running `doorstop`, together with a test.