### PR TITLE
Make MAX_LINE_LENGTH configurable through environment variable

### DIFF
--- a/doorstop/settings.py
+++ b/doorstop/settings.py
@@ -3,6 +3,7 @@
 """Settings for the Doorstop package."""
 
 import logging
+import os
 
 # Logging settings
 DEFAULT_LOGGING_FORMAT = "%(message)s"
@@ -24,7 +25,9 @@ PLACEHOLDER = "..."  # placeholder for new item UIDs on export/import
 PLACEHOLDER_COUNT = 1  # number of placeholders to include on export
 
 # Formatting settings
-MAX_LINE_LENGTH = 79  # line length to trigger multiline on extended attributes
+MAX_LINE_LENGTH = int(
+    os.environ.get("MAX_LINE_LENGTH", 79)
+)  # line length to trigger multiline on extended attributes
 
 # Validation settings
 REFORMAT = True  # reformat item files during validation


### PR DESCRIPTION
Hey, when running the reorder command I sometimes wish for a bit longer line lengths without having to run a script.
Here is a proposal for making it possible to run the following:

```console
$ MAX_LINE_LENGTH=128 doorstop reorder DOC
```