### PR TITLE
Handle backslashes in Reorder operations

### DIFF
--- a/doorstop/cli/tests/test_all.py
+++ b/doorstop/cli/tests/test_all.py
@@ -305,7 +305,7 @@ class TestReorder(unittest.TestCase):
         with open(path, "w") as f:
             f.write(
                 """active: true\nderived: false\nheader: ''\nlevel: 2.4\nlinks: []\n"""
-                """normative: true\nref: ''\nreviewed: null\ntext: |\nEquation """
+                """normative: true\nref: ''\nreviewed: null\ntext: |\n  Equation """
                 """$Eqn = \\frac{a}{b} * \\sigma$"""
             )
             self.addCleanup(os.remove, path)

--- a/doorstop/cli/tests/test_all.py
+++ b/doorstop/cli/tests/test_all.py
@@ -297,6 +297,19 @@ class TestReorder(unittest.TestCase):
         """Verify 'doorstop reorder' returns an error on an unknown prefix."""
         self.assertRaises(SystemExit, main, ['reorder', 'FAKE'])
 
+    def test_reorder_with_backslashes_in_text(self):
+        """Verify 'doorstop reorder' can handle text with backslashes."""
+        number = get_next_number()
+        filename = "TUT{}.yml".format(str(number).zfill(3))
+        path = os.path.join(TUTORIAL, filename)
+        with open(path, "w") as f:
+            f.write(
+                """active: true\nderived: false\nheader: ''\nlevel: 2.4\nlinks: []\n"""
+                """normative: true\nref: ''\nreviewed: null\ntext: |\nEquation """
+                """$Eqn = \\frac{a}{b} * \\sigma$"""
+            )
+            self.addCleanup(os.remove, path)
+        self.assertIs(None, main(['reorder', self.prefix, "--auto"]))
 
 @unittest.skipUnless(os.getenv(ENV), REASON)
 @patch('doorstop.settings.SERVER_HOST', None)

--- a/doorstop/cli/tests/test_all.py
+++ b/doorstop/cli/tests/test_all.py
@@ -311,6 +311,7 @@ class TestReorder(unittest.TestCase):
             self.addCleanup(os.remove, path)
         self.assertIs(None, main(['reorder', self.prefix, "--auto"]))
 
+
 @unittest.skipUnless(os.getenv(ENV), REASON)
 @patch('doorstop.settings.SERVER_HOST', None)
 @patch('doorstop.settings.ADDREMOVE_FILES', False)

--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -565,7 +565,7 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         for item in items:
             space = "    " * item.depth
             lines = item.text.strip().splitlines()
-            comment = lines[0] if lines else ""
+            comment = lines[0].replace("\\", "\\\\") if lines else ""
             line = space + "- {u}: # {c}".format(u=item.uid, c=comment)
             if len(line) > settings.MAX_LINE_LENGTH:
                 line = line[: settings.MAX_LINE_LENGTH - 3] + '...'


### PR DESCRIPTION
Addresses #520 

Backslashes were not escaped during generation of `index.yml` comments, leading to invalid escape errors when math syntax is used.