### PR TITLE
Document how to install pre-releases

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -5,10 +5,19 @@ Doorstop requires [Python](https://www.python.org/) and [Git](https://git-scm.co
 Once Python is installed on your platform, install Doorstop using pip.
 
 ```sh
-pip install doorstop
+$ pip install doorstop
 ```
 
-or add it to your [Poetry](https://python-poetry.org/) project:
+!!! note "Installing Pre-releases"
+    By default, pip only installs stable [releases of Doorstop from PyPi](https://pypi.org/project/doorstop/#history).
+
+    To tell pip to install a pre-release version, [use the `--pre` option](https://pip.pypa.io/en/stable/cli/pip_install/#pre-release-versions):
+
+    ```
+    $ pip install --pre doorstop
+    ```
+
+Alternatively, add it to your [Poetry](https://python-poetry.org/) project:
 
 ```sh
 $ poetry add doorstop

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,9 @@ theme: readthedocs
 extra_css: []
 extra_javascript: []
 
+markdown_extensions:
+  - admonition
+
 nav:
 - Home: index.md
 - Getting Started:


### PR DESCRIPTION
Documents how to install pre-releases from pip, addresses the question in #532.

Also, adds the configuration for [admonitions](https://python-markdown.github.io/extensions/admonition/) support to the MkDocs site.