### PR TITLE
Simplify CI

### DIFF
--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1
-        if: ${{ inputs.os == 'ubuntu-latest' && matrix.python-version == '3.9' }}
+        if: ${{ inputs.os == 'ubuntu-latest' && matrix.python-version == '3.9' && github.repository == 'doorstop-dev/doorstop' }}
         with:
           fail_ci_if_error: true
 

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@v1
-        if: ${{ inputs.os == 'ubuntu-latest' }}
+        if: ${{ inputs.os == 'ubuntu-latest' && matrix.python-version == '3.9' }}
         with:
           fail_ci_if_error: true
 

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -2,9 +2,6 @@ name: Execute tests
 on:
   workflow_call:
     inputs:
-      architecture:
-        required: true
-        type: string
       basepath:
         required: true
         type: string
@@ -46,7 +43,7 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: ${{ inputs.architecture }}
+          architecture: x64
 
       - uses: Gr1N/setup-poetry@v7
 

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -6,7 +6,6 @@ jobs:
   Test:
     uses: ./.github/workflows/execute-tests.yml
     with:
-      architecture: x64
       basepath: "/home/runner/work"
       os: "ubuntu-latest"
       workpath: "/home/runner/work/doorstop/doorstop"

--- a/.github/workflows/test-osx.yml
+++ b/.github/workflows/test-osx.yml
@@ -6,7 +6,6 @@ jobs:
   Test:
     uses: ./.github/workflows/execute-tests.yml
     with:
-      architecture: x64
       basepath: "/Users/runner/work"
       os: "macos-latest"
       workpath: "/Users/runner/work/doorstop/doorstop"

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -3,12 +3,9 @@ name: Windows
 on: push
 
 jobs:
-
-
   Test:
     uses: ./.github/workflows/execute-tests.yml
     with:
-      architecture: x64
       basepath: 'D:\'
       os: "windows-latest"
       workpath: 'C:\a\doorstop\doorstop'


### PR DESCRIPTION
Removed obsolete architecture arguments.
Only upload coverage measurement for one python version (3.9, feel free to change).
Only upload coverage when repo is **_doorstop-dev/doorstop,_** not on forks, to allow forks to run the Actions successfully.