### PR TITLE
CI on Pull Request

### DIFF
--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -36,7 +36,7 @@ jobs:
         working-directory: ${{ inputs.basepath }}
         run: |
           mkdir -p ${{ inputs.workpath }}
-          mv $env:GITHUB_WORKSPACE ${{ inputs.workpath }}
+          copy $env:GITHUB_WORKSPACE ${{ inputs.workpath }}
           cd ${{ inputs.workpath }}
           ls
           pwd

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -30,13 +30,13 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Change path on Windows
-        if: ${{ input.os == 'windows-latest' }}
+        if: ${{ inputs.os == 'windows-latest' }}
         # Cannot start powershell from a path that does not exist, so change
         # working directory for this step only.
         working-directory: ${{ inputs.basepath }}
         run: |
           mkdir -p ${{ inputs.workpath }}
-          mv $env:GITHUB_WORKSPACE/* ${{ inputs.workpath }}
+          mv $env:GITHUB_WORKSPACE/* ${{ inputs.workpath }}/
           cd ${{ inputs.workpath }}
           ls
           pwd

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -9,7 +9,7 @@ on:
         required: true
         type: string
       workpath:
-        required: false
+        required: true
         type: string
 
 jobs:
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7"]
+        python-version: ["3.7", "3.8", "3.9"]
     name: Python ${{ matrix.python-version }}
 
     defaults:
@@ -36,27 +36,7 @@ jobs:
         working-directory: ${{ inputs.basepath }}
         run: |
           mkdir -p ${{ inputs.workpath }}
-          env
           mv $env:GITHUB_WORKSPACE\* ${{ inputs.workpath }}\ -Force
-          cd ${{ inputs.workpath }}
-          ls -Force
-          pwd
-          cd $env:GITHUB_WORKSPACE
-          ls -Force
-          pwd
-      # - name: Checkout Unix
-      #   if: ${{ inputs.os != 'windows-latest' }}
-      #   run: |
-      #     mkdir -p ${{ inputs.workpath }}
-      #     git clone https://github.com/${{ github.repository }} ${{ inputs.workpath }} --depth 1 --branch $GITHUB_REF_NAME
-      # - name: Checkout Windows
-      #   # Cannot start powershell from a path that does not exist, so change
-      #   # working directory for this step only.
-      #   working-directory: ${{ inputs.basepath }}
-      #   if: ${{ inputs.os == 'windows-latest' }}
-      #   run: |
-      #     mkdir -p ${{ inputs.workpath }}
-      #     git clone https://github.com/${{ github.repository }} ${{ inputs.workpath }} --depth 1 --branch $env:GITHUB_REF_NAME
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.7"]
     name: Python ${{ matrix.python-version }}
 
     defaults:
@@ -66,7 +66,10 @@ jobs:
       - uses: Gr1N/setup-poetry@v7
 
       - name: Check system dependencies
-        run: make doctor
+        run: |
+          ls
+          pwd
+          make doctor
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -39,10 +39,10 @@ jobs:
           env
           mv $env:GITHUB_WORKSPACE\* ${{ inputs.workpath }}\
           cd ${{ inputs.workpath }}
-          ls
+          ls -Force
           pwd
           cd $env:GITHUB_WORKSPACE
-          ls
+          ls -Force
           pwd
       # - name: Checkout Unix
       #   if: ${{ inputs.os != 'windows-latest' }}

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -37,8 +37,11 @@ jobs:
         run: |
           mkdir -p ${{ inputs.workpath }}
           env
-          copy $env:GITHUB_WORKSPACE\* ${{ inputs.workpath }}\
+          mv $env:GITHUB_WORKSPACE\* ${{ inputs.workpath }}\
           cd ${{ inputs.workpath }}
+          ls
+          pwd
+          cd $env:GITHUB_WORKSPACE
           ls
           pwd
       # - name: Checkout Unix

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           mkdir -p ${{ inputs.workpath }}
           env
-          mv $env:GITHUB_WORKSPACE\* ${{ inputs.workpath }}\
+          mv $env:GITHUB_WORKSPACE\* ${{ inputs.workpath }}\ -Force
           cd ${{ inputs.workpath }}
           ls -Force
           pwd

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -26,19 +26,33 @@ jobs:
         working-directory: ${{ inputs.workpath }}
 
     steps:
-      - name: Checkout Unix
-        if: ${{ inputs.os != 'windows-latest' }}
-        run: |
-          mkdir -p ${{ inputs.workpath }}
-          git clone https://github.com/${{ github.repository }} ${{ inputs.workpath }} --depth 1 --branch $GITHUB_REF_NAME
-      - name: Checkout Windows
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Change path on Windows
+        if: ${{ input.os == 'windows-latest' }}
         # Cannot start powershell from a path that does not exist, so change
         # working directory for this step only.
         working-directory: ${{ inputs.basepath }}
-        if: ${{ inputs.os == 'windows-latest' }}
         run: |
           mkdir -p ${{ inputs.workpath }}
-          git clone https://github.com/${{ github.repository }} ${{ inputs.workpath }} --depth 1 --branch $env:GITHUB_REF_NAME
+          mv $env:GITHUB_WORKSPACE/* ${{ inputs.workpath }}
+          cd ${{ inputs.workpath }}
+          ls
+          pwd
+      # - name: Checkout Unix
+      #   if: ${{ inputs.os != 'windows-latest' }}
+      #   run: |
+      #     mkdir -p ${{ inputs.workpath }}
+      #     git clone https://github.com/${{ github.repository }} ${{ inputs.workpath }} --depth 1 --branch $GITHUB_REF_NAME
+      # - name: Checkout Windows
+      #   # Cannot start powershell from a path that does not exist, so change
+      #   # working directory for this step only.
+      #   working-directory: ${{ inputs.basepath }}
+      #   if: ${{ inputs.os == 'windows-latest' }}
+      #   run: |
+      #     mkdir -p ${{ inputs.workpath }}
+      #     git clone https://github.com/${{ github.repository }} ${{ inputs.workpath }} --depth 1 --branch $env:GITHUB_REF_NAME
 
       - uses: actions/setup-python@v2
         with:

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           mkdir -p ${{ inputs.workpath }}
           env
-          copy $env:GITHUB_WORKSPACE/* ${{ inputs.workpath }}/*
+          copy $env:GITHUB_WORKSPACE\* ${{ inputs.workpath }}\
           cd ${{ inputs.workpath }}
           ls
           pwd

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -36,7 +36,7 @@ jobs:
         working-directory: ${{ inputs.basepath }}
         run: |
           mkdir -p ${{ inputs.workpath }}
-          mv $env:GITHUB_WORKSPACE/* ${{ inputs.workpath }}/
+          mv $env:GITHUB_WORKSPACE ${{ inputs.workpath }}
           cd ${{ inputs.workpath }}
           ls
           pwd

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -46,10 +46,7 @@ jobs:
       - uses: Gr1N/setup-poetry@v7
 
       - name: Check system dependencies
-        run: |
-          ls
-          pwd
-          make doctor
+        run: make doctor
 
       - uses: actions/cache@v2
         with:

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -3,13 +3,13 @@ on:
   workflow_call:
     inputs:
       basepath:
-        required: true
+        required: false
         type: string
       os:
         required: true
         type: string
       workpath:
-        required: true
+        required: false
         type: string
 
 jobs:

--- a/.github/workflows/execute-tests.yml
+++ b/.github/workflows/execute-tests.yml
@@ -36,7 +36,8 @@ jobs:
         working-directory: ${{ inputs.basepath }}
         run: |
           mkdir -p ${{ inputs.workpath }}
-          copy $env:GITHUB_WORKSPACE ${{ inputs.workpath }}
+          env
+          copy $env:GITHUB_WORKSPACE/* ${{ inputs.workpath }}/*
           cd ${{ inputs.workpath }}
           ls
           pwd

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -4,6 +4,7 @@ on:
   push:
   pull_request:
     branches: [ develop ]
+
 jobs:
   Test:
     uses: ./.github/workflows/execute-tests.yml

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,14 +1,14 @@
-name: Linux
-
-on:
-  push:
-  pull_request:
-    branches: [ develop ]
-
-jobs:
-  Test:
-    uses: ./.github/workflows/execute-tests.yml
-    with:
-      basepath: "/home/runner/work"
-      os: "ubuntu-latest"
-      workpath: "/home/runner/work/doorstop/doorstop"
+# name: Linux
+#
+# on:
+#   push:
+#   pull_request:
+#     branches: [ develop ]
+#
+# jobs:
+#   Test:
+#     uses: ./.github/workflows/execute-tests.yml
+#     with:
+#       # basepath: "/home/runner/work"
+#       os: "ubuntu-latest"
+#       # workpath: "/home/runner/work/doorstop/doorstop"

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,7 +1,9 @@
 name: Linux
 
-on: push
-
+on:
+  push:
+  pull_request:
+    branches: [ develop ]
 jobs:
   Test:
     uses: ./.github/workflows/execute-tests.yml

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -1,14 +1,13 @@
-# name: Linux
-#
-# on:
-#   push:
-#   pull_request:
-#     branches: [ develop ]
-#
-# jobs:
-#   Test:
-#     uses: ./.github/workflows/execute-tests.yml
-#     with:
-#       # basepath: "/home/runner/work"
-#       os: "ubuntu-latest"
-#       # workpath: "/home/runner/work/doorstop/doorstop"
+name: Linux
+
+on:
+  push:
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  Test:
+    uses: ./.github/workflows/execute-tests.yml
+    with:
+      os: "ubuntu-latest"
+      workpath: "/home/runner/work/doorstop/doorstop"

--- a/.github/workflows/test-osx.yml
+++ b/.github/workflows/test-osx.yml
@@ -1,14 +1,14 @@
-name: macOS
-
-on:
-  push:
-  pull_request:
-    branches: [ develop ]
-
-jobs:
-  Test:
-    uses: ./.github/workflows/execute-tests.yml
-    with:
-      basepath: "/Users/runner/work"
-      os: "macos-latest"
-      workpath: "/Users/runner/work/doorstop/doorstop"
+# name: macOS
+#
+# on:
+#   push:
+#   pull_request:
+#     branches: [ develop ]
+#
+# jobs:
+#   Test:
+#     uses: ./.github/workflows/execute-tests.yml
+#     with:
+#       # basepath: "/Users/runner/work"
+#       os: "macos-latest"
+#       # workpath: "/Users/runner/work/doorstop/doorstop"

--- a/.github/workflows/test-osx.yml
+++ b/.github/workflows/test-osx.yml
@@ -1,14 +1,13 @@
-# name: macOS
-#
-# on:
-#   push:
-#   pull_request:
-#     branches: [ develop ]
-#
-# jobs:
-#   Test:
-#     uses: ./.github/workflows/execute-tests.yml
-#     with:
-#       # basepath: "/Users/runner/work"
-#       os: "macos-latest"
-#       # workpath: "/Users/runner/work/doorstop/doorstop"
+name: macOS
+
+on:
+  push:
+  pull_request:
+    branches: [ develop ]
+
+jobs:
+  Test:
+    uses: ./.github/workflows/execute-tests.yml
+    with:
+      os: "macos-latest"
+      workpath: "/Users/runner/work/doorstop/doorstop"

--- a/.github/workflows/test-osx.yml
+++ b/.github/workflows/test-osx.yml
@@ -1,6 +1,9 @@
 name: macOS
 
-on: push
+on:
+  push:
+  pull_request:
+    branches: [ develop ]
 
 jobs:
   Test:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -1,6 +1,9 @@
 name: Windows
 
-on: push
+on:
+  push:
+  pull_request:
+    branches: [ develop ]
 
 jobs:
   Test:


### PR DESCRIPTION
Regarding checks not being run on PR I believe is due to the removal of the `on: pull_request: branches` key in the Actions yaml files. Without the `pull_request` key, the checks are only being executed on pushes, which in the case of forks happens on the forked repo and not on the main repo. But with the `pull_request` key installed, the checks should be executed on the fork when a contributor pushes to the fork, and then again on the main repo when the PR is created. It does make an "extra" execution for developers that have the access to push directly to the main repo, but I believe that the benefit of having the tests executed on the main repo trumps that.

This PR is testing this.