### PR TITLE
Implementation concept for "mapped" documents to address the multi-parent problem

### DIFF
--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -186,11 +186,14 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
                     self._data[key] = value.strip()
                 elif key == "digits":
                     self._data[key] = int(value)  # type: ignore
+                elif key == "mapped_to":
+                    self._data[key] = value.strip()
                 else:
-                    msg = "unexpected document setting '{}' in: {}".format(
-                        key, self.config
+                    log.debug(
+                        "custom document attribute found:  {} = {}".format(key, value)
                     )
-                    raise DoorstopError(msg)
+                    # custom attribute
+                    self._data[key] = value
             except (AttributeError, TypeError, ValueError):
                 msg = "invalid value for '{}' in: {}".format(key, self.config)
                 raise DoorstopError(msg)
@@ -436,6 +439,10 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         """Delete the document's index if it exists."""
         log.info("deleting {} index...".format(self))
         common.delete(self.index)
+
+    def attribute(self, attrib):
+        """Get the item's custom attribute."""
+        return self._data.get(attrib)
 
     # actions ################################################################
 

--- a/doorstop/core/item.py
+++ b/doorstop/core/item.py
@@ -728,10 +728,18 @@ class Item(BaseFileObject):  # pylint: disable=R0902
         tree = tree or self.tree
         if not document or not tree:
             return child_items, child_documents
+
+        # get list of mapped documents
+        mapped_document_prefixes = document.attribute("mapped_to") if document else []
+        if not mapped_document_prefixes:
+            mapped_document_prefixes = []
+
         # Find child objects
         log.debug("finding item {}'s child objects...".format(self))
         for document2 in tree:
-            if document2.parent == document.prefix:
+            if (document2.parent == document.prefix) or (
+                document2.prefix in mapped_document_prefixes
+            ):
                 child_documents.append(document2)
                 # Search for child items unless we only need to find one
                 if not child_items or find_all:

--- a/doorstop/core/tests/__init__.py
+++ b/doorstop/core/tests/__init__.py
@@ -4,7 +4,7 @@
 
 import logging
 import os
-from typing import List
+from typing import Dict, List
 from unittest.mock import MagicMock, Mock, patch
 
 from doorstop.core.base import BaseFileObject
@@ -95,12 +95,19 @@ class MockSimpleDocument:
         self.prefix = "RQ"
         self._items: List[Item] = []
         self.extended_reviewed: List[str] = []
+        self._data: Dict[str, str] = {}
 
     def __iter__(self):
         yield from self._items
 
     def set_items(self, items):
         self._items = items
+
+    def set_data(self, data):
+        self._data = data
+
+    def attribute(self, name):
+        return self._data.get(name)
 
 
 class MockDocumentSkip(MockDocument):  # pylint: disable=W0223,R0902

--- a/doorstop/core/tests/test_document.py
+++ b/doorstop/core/tests/test_document.py
@@ -159,8 +159,8 @@ class TestDocument(unittest.TestCase):
     def test_load_unknown(self):
         """Verify loading a document config with an unknown key fails."""
         self.document._file = YAML_UNKNOWN
-        msg = "^unexpected document setting 'John' in: .*\\.doorstop.yml$"
-        self.assertRaisesRegex(DoorstopError, msg, self.document.load)
+        self.document.load()
+        self.assertEqual("Doe", self.document.attribute("John"))
 
     def test_load_unknown_attributes(self):
         """Verify loading a document config with unknown attributes fails."""

--- a/doorstop/core/tree.py
+++ b/doorstop/core/tree.py
@@ -627,9 +627,16 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
     def _draw_lines(self, encoding, html_links=False):
         """Generate lines of the tree structure."""
         # Build parent prefix string (`getattr` to enable mock testing)
-        prefix = getattr(self.document, "prefix", "") or str(self.document)
+        prefix_link = prefix = getattr(self.document, "prefix", "") or str(
+            self.document
+        )
+
+        attribute_fn = getattr(self.document, "attribute", None)
+        mapped = attribute_fn("mapped_to") if callable(attribute_fn) else None
+
+        prefix += " (" + ",".join(mapped) + ")" if mapped else ""
         if html_links:
-            prefix = '<a href="documents/{0}">{0}</a>'.format(prefix)
+            prefix = '<a href="documents/{0}">{1}</a>'.format(prefix_link, prefix)
         yield prefix
         # Build child prefix strings
         for count, child in enumerate(self.children, start=1):


### PR DESCRIPTION
This PR implements the notion of a "mapped" document which addresses (to some extend) the multi-parent problem.

I'm coming from a medical device software development environment and have similar requirements as mentioned in #509 . We are using Caliber for most of the requirements and the idea is derived from how we define traces there. It depends on what exactly you need to achieve, but please read on and comment on the proposal

Context:

* Assume we  have the following tree  Feature_Req <- SW_Req <- SW_Test, and now we have a TRA (thread and risk analysis) which "generates" new mitigation requirements based on the Feature_Req.
* I'm also assuming now that the following is sufficient: EVERY requirement from TRA needs to be picked up by the SW_req (implemented)  , but NOT EVERY SW-Req needs to trace to a TRA requirement. In our case this holds true because we need to make sure that all TRA elements are implemented, but not every SW Req actually need one
* on a side note: in order to verify that all TRA requiremetns a tested, a new TRA_Test document could be created as a child to the TRA itself.
* the main difference to normal tracing in `doorstop` is, that in for normal trace EVERY requirement in a child document needs to trace to a parent req, unless it is derived. Here it is more saying: "no matter what you do elsewhere in the mapped document, you need to pick up all my requirements at least somewhere". This loosens the tight tracing requirements that would  break with *multi-parent* approach. 

If the assumptions are above are valid, then the implementation sketch looks like this

1. let's define a document that holds the TRA: normal document dependencies, child doc of Feature_Req
2. configure an "mapped_to" attribute in the TRA document that lists the documents that need to pick up all the requirements from the TRA, in our case this would list "SW_Req"
3. as a sanity check we could make sure that the mapped document is neither a parent of a child of the current document (direct or indirect, to avoid trace loops) - not done yet
4. when validating document we  check for the existence of the `mapped_to` attribute and validate whether all items from this document are actually picked up by the "mapped_to" document(s). It's not checked, as in the normal case, whether every child document requirement will have a link to this "mapped" parent

Main effort is in the `item_validator`. In addition, a new attribute on document level has been introduced ( and because i need it for something else, also a general "custom attribute" feature similar to items). 

All existing tests are working fine, no tests for the new implementation exist yet. Please review and if this would be a candiate for integration into the upstream repo then the tests and doc updates  follow.