### PR TITLE
Fixed issue #497

### DIFF
--- a/doorstop/server/main.py
+++ b/doorstop/server/main.py
@@ -122,7 +122,8 @@ def run(args, cwd, _):
 @hook("before_request")
 def strip_path():
     request.environ["PATH_INFO"] = request.environ["PATH_INFO"].rstrip("/")
-    request.environ["PATH_INFO"] = request.environ["PATH_INFO"].rstrip(".html")
+    if len(request.environ["PATH_INFO"]) > 0 and request.environ["PATH_INFO"][-5:-1] == ".html":
+        request.environ["PATH_INFO"] = request.environ["PATH_INFO"][:-5]
 
 
 @hook("after_request")


### PR DESCRIPTION
The issue stated that doorstop false truncated all files that end with lowercase "t" on its server, it is due to the rstrip(".html") function which deleted all "h, t, m, l"s at the end of a file name. Fixed it by detecting the file ended with ".html" and deleted the particular suffix.

Also, I'd love to open another discussion that doorstop should tell the users their file name cannot be "all", otherwise, the get request will automatically be transferred to the "/documents/all" request (file at doorstop/server/main.py). Another solution would be to delete the "/documents/all" request since it seems to be the same as the "/documents" to me. Moreover, there also should not be any "/" characters existing in the users' file since they will all be truncated as well (although that is not likely to happen).