### PR TITLE
Add support for pyyaml 6.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ classifiers = [
 
 python = "^3.8"
 
-pyyaml = "^5.1"
+pyyaml = "^5.1,^6.0"
 markdown = "^3.3.6"
 bottle = "~0.12.13"
 requests = "^2.0"


### PR DESCRIPTION
Pyyaml 6.0 is relatively old now, so should be supported.

Fixes #604 