### PR TITLE
Custom item validator per folder

### DIFF
--- a/docs/api/scripting.md
+++ b/docs/api/scripting.md
@@ -72,3 +72,39 @@ if __name__ == '__main__':
 ```
 
 Both `document_hook` and `item_hook` are optional, but if provided these callbacks will be passed each corresponding instance. Each callback should yield instances of Doorstop's exception classes based on severity of the issue.
+
+## Validation Hook per folder
+
+Doorstop also has an extension which allows creating an item validation per folder, allowing the document to have different validations for each document section.
+To enable this mechanism you must insert into your `.doorstop.yml` file the following lines:
+
+```yaml
+extensions:
+  item_validator: .req_sha_item_validator.py # a python file path relative to .doorstop.yml
+```
+
+or
+
+```yaml
+extensions:
+  item_validator: ../validators/my_complex_validator.py # a python file path relative to .doorstop.yml
+```
+
+The referenced file must have a function called `item_validator` with a single parameter `item`.
+
+Example:
+
+```python
+
+
+def item_validator(item):
+    if getattr(item, "references") == None:
+        return [] # early return
+    for ref in item.references:
+        if ref['sha'] != item._hash_reference(ref['path']):
+            yield DoorstopError("Hash has changed and it was not reviewed properly")
+
+```
+
+Although it is not required, it is recommended to yield a Doorstop type such as,
+`DoorstopInfo`, `DoorstopError`, or `DoorstopWarning`.

--- a/doorstop/core/tests/__init__.py
+++ b/doorstop/core/tests/__init__.py
@@ -4,7 +4,7 @@
 
 import logging
 import os
-from typing import List
+from typing import Any, Dict, List
 from unittest.mock import MagicMock, Mock, patch
 
 from doorstop.core.base import BaseFileObject
@@ -95,12 +95,22 @@ class MockSimpleDocument:
         self.itemformat = "yaml"
         self._items: List[Item] = []
         self.extended_reviewed: List[str] = []
+        self.extensions: Dict[str, Any] = {}
 
     def __iter__(self):
         yield from self._items
 
     def set_items(self, items):
         self._items = items
+
+
+class MockSimpleDocumentExtensions(MockSimpleDocument):
+    """Mock Document class that enable extensions."""
+
+    def __init__(self, **kwargs):
+        super().__init__()
+        for k, v in kwargs.items():
+            self.extensions[k] = v
 
 
 class MockDocumentSkip(MockDocument):  # pylint: disable=W0223,R0902

--- a/doorstop/core/tests/test_item_extensions.py
+++ b/doorstop/core/tests/test_item_extensions.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+# pylint: disable=C0302
+
+"""Unit tests for the doorstop.core.item with extensions enabled."""
+
+import os
+import unittest
+from types import ModuleType
+from unittest.mock import patch
+
+from doorstop.common import import_path_as_module
+from doorstop.core.tests import TESTS_ROOT, MockItem, MockSimpleDocumentExtensions
+
+
+class TestItem(unittest.TestCase):
+    """Unit tests for the Item class."""
+
+    # pylint: disable=protected-access,no-value-for-parameter
+
+    def setUp(self):
+        path = os.path.join("path", "to", "RQ001.yml")
+        self.item = MockItem(MockSimpleDocumentExtensions(), path)
+
+    @patch("doorstop.settings.CACHE_PATHS", False)
+    def test_load_custom_validator_per_folder(self):
+        """Load a valid custom validator per folder."""
+        path = os.path.join("path", "to", "RQ001.yml")
+        self.item = MockItem(
+            MockSimpleDocumentExtensions(
+                item_validator=f"{TESTS_ROOT}/validators/validator_dummy.py"
+            ),
+            path,
+        )
+        document = self.item.document
+        validator = import_path_as_module(document.extensions["item_validator"])
+
+        self.assertEqual(isinstance(validator, ModuleType), True)
+
+    @patch("doorstop.settings.CACHE_PATHS", False)
+    def test_load_custom_validator_per_folder_and_fails(self):
+        """Load a invalid custom validator per folder and fails with FileNotFoundError."""
+        path = os.path.join("path", "to", "RQ001.yml")
+        self.item = MockItem(
+            MockSimpleDocumentExtensions(
+                item_validator=f"{TESTS_ROOT}/files/validator_dummy2.py"
+            ),
+            path,
+        )
+        document = self.item.document
+        try:
+            validator = import_path_as_module(document.extensions["item_validator"])
+        except FileNotFoundError:
+            validator = FileNotFoundError
+
+        self.assertEqual(FileNotFoundError, validator)

--- a/doorstop/core/tests/validators/validator_dummy.py
+++ b/doorstop/core/tests/validators/validator_dummy.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: LGPL-3.0-only
+
+from doorstop import DoorstopError, DoorstopInfo, DoorstopWarning
+
+
+def item_validator(item):
+    if item:
+        yield DoorstopInfo("Loaded")


### PR DESCRIPTION
Hi @jacebrowning, we have been using doorstop to manage our ISO 26262 requirements, it is part of our core workflow.

We have improved certain areas of the software to match our requirements, and we think it would be useful to share with upstream these changes.

- Load a file as a python module
- A new section inside `.doorstop.yml`  to enable them (we called them extension, as we intend to add more features if necessary) 
       -  Where we can define a custom validator for the items from a specific folder
       -  If file references from this folder should calculate the SHA-256 for them (During review / validate without `-W`)
            -  Change the buffer size for when doing the SHA
- Override doorstop settings from a file through CLI parameter.
 
We made these changes because we didn't want to override most of the default behaviour from doorstop, and yet we wanted to be able to tweak certain validations for specific items.
