### PR TITLE
Add ability to remove inactive items

### DIFF
--- a/doorstop/cli/commands.py
+++ b/doorstop/cli/commands.py
@@ -207,7 +207,7 @@ def run_remove(args, cwd, _, catch=True):
     with utilities.capture(catch=catch) as success:
         # get the item
         tree = _get_tree(args, cwd)
-        item = tree.find_item(args.uid,only_active=False)
+        item = tree.find_item(args.uid, only_active=False)
 
         # delete it
         item.delete()

--- a/doorstop/cli/commands.py
+++ b/doorstop/cli/commands.py
@@ -207,7 +207,7 @@ def run_remove(args, cwd, _, catch=True):
     with utilities.capture(catch=catch) as success:
         # get the item
         tree = _get_tree(args, cwd)
-        item = tree.find_item(args.uid)
+        item = tree.find_item(args.uid,only_active=False)
 
         # delete it
         item.delete()

--- a/doorstop/cli/tests/test_all.py
+++ b/doorstop/cli/tests/test_all.py
@@ -22,8 +22,8 @@ from doorstop.cli.tests import (
 from doorstop.core.builder import _clear_tree
 from doorstop.core.document import Document
 
-REQ_COUNT = 23
-ALL_COUNT = 55
+REQ_COUNT = 24
+ALL_COUNT = 56
 
 
 class TempTestCase(unittest.TestCase):
@@ -218,17 +218,25 @@ class TestRemove(unittest.TestCase):
     """Integration tests for the 'doorstop remove' command."""
 
     ITEM = os.path.join(TUTORIAL, "TUT003.yml")
+    INACTIVE_ITEM = os.path.join(TUTORIAL, "TUT026.yml")
 
     def setUp(self):
         self.backup = common.read_text(self.ITEM)
+        self.inactive_backup = common.read_text(self.INACTIVE_ITEM)
 
     def tearDown(self):
         common.write_text(self.backup, self.ITEM)
+        common.write_text(self.inactive_backup, self.INACTIVE_ITEM)
 
     def test_remove(self):
         """Verify 'doorstop remove' can be called."""
         self.assertIs(None, main(["remove", "tut3"]))
         self.assertFalse(os.path.exists(self.ITEM))
+
+    def test_remove_inactive(self):
+        """Verify 'doorstop remove' can remove inactive"""
+        self.assertIs(None, main(["remove", "tut26"]))
+        self.assertFalse(os.path.exists(self.INACTIVE_ITEM))
 
     def test_remove_error(self):
         """Verify 'doorstop remove' returns an error on unknown item UIDs."""

--- a/doorstop/core/builder.py
+++ b/doorstop/core/builder.py
@@ -94,10 +94,15 @@ def find_document(prefix):
     return document
 
 
-def find_item(uid):
-    """Find an item without an explicitly building a tree."""
+def find_item(uid,only_active = True):
+    """Find an item without an explicitly building a tree.
+    
+    :param uid:  UID
+    :param only_active: Returns only active items
+
+    """
     tree = _get_tree()
-    item = tree.find_item(uid)
+    item = tree.find_item(uid,only_active=only_active)
     return item
 
 

--- a/doorstop/core/builder.py
+++ b/doorstop/core/builder.py
@@ -94,15 +94,15 @@ def find_document(prefix):
     return document
 
 
-def find_item(uid,only_active = True):
+def find_item(uid, only_active=True):
     """Find an item without an explicitly building a tree.
-    
+
     :param uid:  UID
     :param only_active: Returns only active items
 
     """
     tree = _get_tree()
-    item = tree.find_item(uid,only_active=only_active)
+    item = tree.find_item(uid, only_active=only_active)
     return item
 
 

--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -562,7 +562,7 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
 
         """
         uid = UID(value)
-        item = self.find_item(uid,only_active=False)
+        item = self.find_item(uid, only_active=False)
         item.delete()
         if reorder:
             self.reorder()
@@ -780,7 +780,7 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
             for item in items_at_level:
                 yield level, item
 
-    def find_item(self, value, only_active = True, _kind=""):
+    def find_item(self, value, only_active=True, _kind=""):
         """Return an item by its UID.
 
         :param value: item or UID
@@ -798,7 +798,7 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
                 if item.active:
                     return item
                 else:
-                    log.trace("item is inactive: {}".format(item))  # type: ignore'
+                    log.trace("item is inactive: {}".format(item))  # type: ignore
                     if not only_active:
                         return item
 

--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -562,7 +562,7 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
 
         """
         uid = UID(value)
-        item = self.find_item(uid)
+        item = self.find_item(uid,only_active=False)
         item.delete()
         if reorder:
             self.reorder()
@@ -780,10 +780,11 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
             for item in items_at_level:
                 yield level, item
 
-    def find_item(self, value, _kind=""):
+    def find_item(self, value, only_active = True, _kind=""):
         """Return an item by its UID.
 
         :param value: item or UID
+        :param only_active: Returns only active items
 
         :raises: :class:`~doorstop.common.DoorstopError` if the item
             cannot be found
@@ -797,7 +798,9 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
                 if item.active:
                     return item
                 else:
-                    log.trace("item is inactive: {}".format(item))  # type: ignore
+                    log.trace("item is inactive: {}".format(item))  # type: ignore'
+                    if not only_active:
+                        return item
 
         raise DoorstopError("no matching{} UID: {}".format(_kind, uid))
 

--- a/doorstop/core/tests/test_builder.py
+++ b/doorstop/core/tests/test_builder.py
@@ -52,7 +52,7 @@ class TestModule(unittest.TestCase):
         _clear_tree()
         uid = "req1"
         find_item(uid)
-        mock_find_item.assert_called_once_with(uid)
+        mock_find_item.assert_called_once_with(uid,only_active=True)
 
     def test_tree_finds_documents(self):
         """Verify items can be found using a convenience function."""

--- a/doorstop/core/tests/test_builder.py
+++ b/doorstop/core/tests/test_builder.py
@@ -52,7 +52,7 @@ class TestModule(unittest.TestCase):
         _clear_tree()
         uid = "req1"
         find_item(uid)
-        mock_find_item.assert_called_once_with(uid,only_active=True)
+        mock_find_item.assert_called_once_with(uid, only_active=True)
 
     def test_tree_finds_documents(self):
         """Verify items can be found using a convenience function."""

--- a/doorstop/core/tests/test_document.py
+++ b/doorstop/core/tests/test_document.py
@@ -580,6 +580,15 @@ outline:
         mock_reorder.assert_called_once_with(self.document.items, keep=None, start=None)
         mock_remove.assert_called_once_with(item.path)
 
+    @patch("doorstop.core.document.Document._reorder_automatic")
+    @patch("os.remove")
+    def test_remove_inactive_item(self, mock_remove, mock_reorder):
+        """Verify an item can be removed."""
+        with patch("doorstop.settings.REORDER", True):
+            item = self.document.remove_item("REQ005")
+        mock_reorder.assert_called_once_with(self.document.items, keep=None, start=None)
+        mock_remove.assert_called_once_with(item.path)
+
     @patch("os.remove")
     def test_remove_item_contains(self, mock_remove):
         """Verify a removed item is not contained in the document."""

--- a/doorstop/core/tests/test_tree.py
+++ b/doorstop/core/tests/test_tree.py
@@ -320,6 +320,13 @@ class TestTree(unittest.TestCase):
         self.tree.remove_item("req1", reorder=False)
         mock_delete.assert_called_once_with()
 
+    @patch("doorstop.settings.REORDER", False)
+    @patch("doorstop.core.item.Item.delete")
+    def test_remove_inactive_item(self, mock_delete):
+        """Verify an item can be removed from a document."""
+        self.tree.remove_item("req5", reorder=False)
+        mock_delete.assert_called_once_with()
+
     def test_remove_item_unknown_item(self):
         """Verify an exception is raised removing an unknown item."""
         self.assertRaises(DoorstopError, self.tree.remove_item, "req9999")

--- a/doorstop/core/tree.py
+++ b/doorstop/core/tree.py
@@ -276,7 +276,7 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
         uid = UID(value)
         for document in self:
             try:
-                document.find_item(uid,only_active=False)
+                document.find_item(uid, only_active=False)
             except DoorstopError:
                 pass  # item not found in that document
             else:
@@ -445,7 +445,7 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
         except KeyError:
             for document in self:
                 try:
-                    item = document.find_item(uid, only_active=only_active,_kind=_kind)
+                    item = document.find_item(uid, only_active=only_active, _kind=_kind)
                 except DoorstopError:
                     pass  # item not found in that document
                 else:

--- a/doorstop/core/tree.py
+++ b/doorstop/core/tree.py
@@ -276,7 +276,7 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
         uid = UID(value)
         for document in self:
             try:
-                document.find_item(uid)
+                document.find_item(uid,only_active=False)
             except DoorstopError:
                 pass  # item not found in that document
             else:
@@ -415,10 +415,11 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
 
         raise DoorstopError(Prefix.UNKNOWN_MESSAGE.format(prefix))
 
-    def find_item(self, value, _kind=""):
+    def find_item(self, value, only_active=True, _kind=""):
         """Get an item by its UID.
 
         :param value: item or UID
+        :param only_active: Returns only active items
 
         :raises: :class:`~doorstop.common.DoorstopError` if the item
             cannot be found
@@ -437,12 +438,14 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
                     return item
                 else:
                     log.trace("item is inactive: {}".format(item))  # type: ignore
+                    if not only_active:
+                        return item
             else:
                 log.trace("found cached unknown: {}".format(uid))  # type: ignore
         except KeyError:
             for document in self:
                 try:
-                    item = document.find_item(uid, _kind=_kind)
+                    item = document.find_item(uid, only_active=only_active,_kind=_kind)
                 except DoorstopError:
                     pass  # item not found in that document
                 else:
@@ -454,6 +457,8 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
                         return item
                     else:
                         log.trace("item is inactive: {}".format(item))  # type: ignore
+                        if not only_active:
+                            return item
 
             log.debug("could not find item: {}".format(uid))
             if settings.CACHE_ITEMS:

--- a/reqs/tutorial/TUT026.yml
+++ b/reqs/tutorial/TUT026.yml
@@ -1,0 +1,10 @@
+active: true
+derived: false
+header: ''
+level: 5.2
+links: []
+normative: true
+ref: ''
+reviewed: jQyhY-PAEhuHr8zx7e2HRBUZACSJNbxvhAagi90VYw8=
+text: |
+  An inactive requirement.


### PR DESCRIPTION
This is to close #396. 

The find_item methods are extended with the argument `only_active` that defaults to true to keep the old behaviour intact. The various delete functions calls find_item with `only_active=False` to find any inactive items and be able to delete them.

Test cases are added with copies of the various test cases to remove an item but to try remove req5 that is inactive. Some test files used the test cases in the tutorial folder, as I could not find an inactive req there I added tut26 as an inactive case in that folder. 