### PR TITLE
Allow hidden paths to be referenced

### DIFF
--- a/doorstop/core/vcs/base.py
+++ b/doorstop/core/vcs/base.py
@@ -94,8 +94,8 @@ class BaseWorkingCopy(metaclass=ABCMeta):
                     # Skip ignored paths
                     if self.ignored(relpath):
                         continue
-                    # Skip hidden paths
-                    if os.path.sep + "." in os.path.sep + relpath:
+                    # Skip hidden paths according to settings definition
+                    if not settings.ALLOW_HIDDEN_PATH_REFERENCES:
                         continue
                     self._path_cache.append((path, filename, relpath))
         yield from self._path_cache

--- a/doorstop/settings.py
+++ b/doorstop/settings.py
@@ -24,6 +24,9 @@ RESERVED_WORDS = ["all"]  # keywords that cannot be used for prefixes
 PLACEHOLDER = "..."  # placeholder for new item UIDs on export/import
 PLACEHOLDER_COUNT = 1  # number of placeholders to include on export
 
+# VCS Behaviour
+ALLOW_HIDDEN_PATH_REFERENCES=False
+
 # Formatting settings
 MAX_LINE_LENGTH = 79  # line length to trigger multiline on extended attributes
 


### PR DESCRIPTION
Hi @jacebrowning, @neerdoc I've created a new issue (#650) and I'm proposing to do not ignore hidden paths as part of the reference path as I think sometimes we want to reference files inside them (e.g., CI config files)


Regards,
Lucas