### PR TITLE
Update build-system requirement to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,5 +108,5 @@ profile = "black"
 
 [build-system]
 
-requires = ["poetry>=0.12"]
+requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Build system was changed in ddbe061e52c1e2ff08bd7a9066b987071713a6fa
to use poetry-core, but pyproject.toml still depends on the whole
poetry
