### PR TITLE
Fix runner version to macos-13, as setup-python only support >=3.11 on osx 14

### DIFF
--- a/.github/workflows/test-osx.yml
+++ b/.github/workflows/test-osx.yml
@@ -9,5 +9,5 @@ jobs:
   Test:
     uses: ./.github/workflows/execute-tests.yml
     with:
-      os: "macos-latest"
+      os: "macos-13"
       workpath: "/Users/runner/work/doorstop/doorstop"


### PR DESCRIPTION
This is a limitation in setup-python, and a quick fix.

I think a better solution would be to use matrix for the os's and then use exclude for unsupported versions and possibly also use poetry environments for the different python versions, though this would be a bigger change to the CI. 
Let me know if that would be of interest.