### PR TITLE
Only run change-coverage for PRs

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -11,6 +11,7 @@ jobs:
     with:
       os: "ubuntu-latest"
       workpath: "/home/runner/work/doorstop/doorstop"
+    if: github.event_name == 'pull_request'
 
   Test:
     uses: ./.github/workflows/execute-tests.yml


### PR DESCRIPTION
change-coverage should only run on branches - it fails when on `develop` branch