### PR TITLE
Fix missing HTML publisher index and matrix links

### DIFF
--- a/doorstop/core/publishers/html.py
+++ b/doorstop/core/publishers/html.py
@@ -109,6 +109,8 @@ class HtmlPublisher(MarkdownPublisher):
                     "major": "-",
                     "minor": "",
                 },
+                has_index=self.getIndex(),
+                has_matrix=self.getMatrix(),
             )
             common.write_text(html, path)
         else:
@@ -183,6 +185,8 @@ class HtmlPublisher(MarkdownPublisher):
                 "major": "-",
                 "minor": "",
             },
+            has_index=self.getIndex(),
+            has_matrix=self.getMatrix(),
         )
         common.write_text(html, path)
 


### PR DESCRIPTION
The current `html.py` publisher does not pass the `has_index` and `has_matrix` flags for the index and matrix pages -- it only does it correctly in the `lines` method. This change fixes that and gives proper navigation to the index and matrix headers