### PR TITLE
make html template contents menu scrollable

### DIFF
--- a/doorstop/core/files/templates/html/doorstop.css
+++ b/doorstop/core/files/templates/html/doorstop.css
@@ -2,6 +2,11 @@
 .caption {
     text-align: center;
     font-size:15px;
-    }
+}
 
 #img {width: 100%}
+
+.contents-menu {
+    max-height: 85vh;
+    overflow-y: scroll;
+}

--- a/doorstop/views/doorstop.tpl
+++ b/doorstop/views/doorstop.tpl
@@ -29,7 +29,7 @@
             <a class="nav-link dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
               Contents
             </a>
-            <ul class="dropdown-menu">
+            <ul class="dropdown-menu contents-menu">
               % old_depth = 0
               % for item in toc:
               %   if item['depth'] > old_depth:


### PR DESCRIPTION
The current HTML template contents menu dropdown is not scrollable if it exceeds the page height. This fixes that.