### PR TITLE
Fix repeated Heading text

### DIFF
--- a/doorstop/core/publishers/markdown.py
+++ b/doorstop/core/publishers/markdown.py
@@ -268,7 +268,11 @@ class MarkdownPublisher(BasePublisher):
             # Text
             if item.text:
                 yield ""  # break before text
-                yield from item.text.splitlines()
+                if item.heading:
+                    # First line was already printed in the heading. Do not repeat.
+                    yield from item.text.splitlines()[1:]
+                else:
+                    yield from item.text.splitlines()
 
             # Reference
             if item.ref:


### PR DESCRIPTION
The current implementation uses the first line of the `text` field on `heading` items to display the heading. However, it then repeats that line below the heading. This PR fixes that by excluding the first line from being printed for `heading` items. Successive lines are still printed since they are not included in the heading.