### PR TITLE
736 - Heading title

### DIFF
--- a/doorstop/core/item.py
+++ b/doorstop/core/item.py
@@ -573,6 +573,34 @@ class Item(BaseFileObject):  # pylint: disable=R0902
         if settings.ENABLE_HEADERS:
             self._data["header"] = Text(value)
 
+    def title(self):
+        """Get the item's title.
+        
+        Read from either the header or the first line of the text field.
+
+        """
+        if self.header:
+            return self.header
+        lines = self.text.splitlines()
+        if lines:
+            return lines[0]
+        return ""
+
+    def description(self):
+        """Get the item's description.
+        
+        Read from the text field, omitting the first line if it would be
+        included in the item's title.
+
+        """
+        if self.header:
+            # Header is specified, so no need to omit the first line
+            return self.text
+        lines = self.text.splitlines()
+        if lines:
+            return lines[1:]
+        return ""
+
     @property  # type: ignore
     @auto_load
     def ref(self):

--- a/doorstop/core/publishers/html.py
+++ b/doorstop/core/publishers/html.py
@@ -355,17 +355,18 @@ class HtmlPublisher(MarkdownPublisher):
         for item in iter_items(toc_doc):
             # Check if item has the attribute heading.
             if item.heading:
-                lines = item.text.splitlines()
-                heading = lines[0] if lines else ""
+                heading = item.title()
             elif item.header:
                 heading = "{h}".format(h=item.header)
             else:
                 heading = item.uid
+
             if settings.PUBLISH_HEADING_LEVELS:
                 level = format_level(item.level)
                 lbl = "{lev} {h}".format(lev=level, h=heading)
             else:
                 lbl = heading
+
             if linkify:
                 uid = item.uid
             else:

--- a/doorstop/core/publishers/latex.py
+++ b/doorstop/core/publishers/latex.py
@@ -98,25 +98,23 @@ class LaTeXPublisher(BasePublisher):
             heading_level = "\\" + "sub" * (item.depth - 1) + "section{"
 
             if item.heading:
-                text_lines = item.text.splitlines()
-                if item.header:
-                    text_lines.insert(0, item.header)
+                title = item.title()
                 # Level and Text
                 if settings.PUBLISH_HEADING_LEVELS:
                     standard = "{h}{t}{he}".format(
                         h=heading_level,
-                        t=_latex_convert(text_lines[0]) if text_lines else "",
+                        t=_latex_convert(title) if title else "",
                         he="}",
                     )
                 else:
                     standard = "{h}{t}{he}".format(
                         h=heading,
-                        t=_latex_convert(text_lines[0]) if text_lines else "",
+                        t=_latex_convert(title) if title else "",
                         he="}",
                     )
                 attr_list = self.format_attr_list(item, True)
                 yield standard + attr_list
-                yield from self._format_latex_text(text_lines[1:])
+                yield from self._format_latex_text(item.text.splitlines())
             else:
                 uid = item.uid
                 if settings.ENABLE_HEADERS:

--- a/doorstop/core/publishers/markdown.py
+++ b/doorstop/core/publishers/markdown.py
@@ -168,8 +168,7 @@ class MarkdownPublisher(BasePublisher):
 
             # Check if item has the attribute heading.
             if item.heading:
-                lines = item.text.splitlines()
-                heading = lines[0] if lines else ""
+                heading = item.title()
             elif item.header:
                 heading = "{h}".format(h=item.header)
             else:
@@ -214,17 +213,14 @@ class MarkdownPublisher(BasePublisher):
         heading = "#" * item.depth
         level = format_level(item.level)
         if item.heading:
-            text_lines = item.text.splitlines()
-            if item.header:
-                text_lines.insert(0, item.header)
             # Level and Text
             if settings.PUBLISH_HEADING_LEVELS:
                 standard = "{h} {lev} {t}".format(
-                    h=heading, lev=level, t=text_lines[0] if text_lines else ""
+                    h=heading, lev=level, t=item.title()
                 )
             else:
                 standard = "{h} {t}".format(
-                    h=heading, t=text_lines[0] if text_lines else ""
+                    h=heading, t=item.title()
                 )
             attr_list = self.format_attr_list(item, True)
             result = standard + attr_list


### PR DESCRIPTION
Fixes https://github.com/doorstop-dev/doorstop/issues/736

Adds `item.title` and `item.description` methods rather than having the logic to get a `heading` type item's title repeated in several locations, and fixes a bug where the text could sometimes be missing the first line. Details described in the issue noted above.