### PR TITLE
updated MAthJax configuration

### DIFF
--- a/doorstop/core/tests/files/published.html
+++ b/doorstop/core/tests/files/published.html
@@ -6,11 +6,19 @@
   <link rel="stylesheet" href="../template/bootstrap.min.css" />
   <link rel="stylesheet" href="../template/general.css" />
   <link type="text/css" rel="stylesheet" href="../template/doorstop.css" />
+  <!-- Load MathJax 3 from the template directory -->
   <script src="../template/tex-mml-chtml.js" id="MathJax-script" async></script>
-  <script type="text/x-mathjax-config">
-  MathJax.Hub.Config({
-    tex2jax: {inlineMath: [["$","$"],["\\(","\\)"]]}
-  });
+  <!-- MathJax 3 Configuration -->
+  <script>
+  MathJax = {
+    tex: {
+      inlineMath: [['$', '$'], ['\\(', '\\)']],
+      displayMath: [['$$', '$$'], ['\\[', '\\]']]
+    },
+    svg: {
+      fontCache: 'global'
+    }
+  };
   </script>
 </head>
 <body>

--- a/doorstop/core/tests/files/published2.html
+++ b/doorstop/core/tests/files/published2.html
@@ -6,11 +6,19 @@
   <link rel="stylesheet" href="../template/bootstrap.min.css" />
   <link rel="stylesheet" href="../template/general.css" />
   <link type="text/css" rel="stylesheet" href="../template/doorstop.css" />
+  <!-- Load MathJax 3 from the template directory -->
   <script src="../template/tex-mml-chtml.js" id="MathJax-script" async></script>
-  <script type="text/x-mathjax-config">
-  MathJax.Hub.Config({
-    tex2jax: {inlineMath: [["$","$"],["\\(","\\)"]]}
-  });
+  <!-- MathJax 3 Configuration -->
+  <script>
+  MathJax = {
+    tex: {
+      inlineMath: [['$', '$'], ['\\(', '\\)']],
+      displayMath: [['$$', '$$'], ['\\[', '\\]']]
+    },
+    svg: {
+      fontCache: 'global'
+    }
+  };
   </script>
 </head>
 <body>

--- a/doorstop/views/base.tpl
+++ b/doorstop/views/base.tpl
@@ -13,11 +13,19 @@
   <link rel="stylesheet" href="{{baseurl}}{{tmpRef}}template/bootstrap.min.css" />
   <link rel="stylesheet" href="{{baseurl}}{{tmpRef}}template/general.css" />
   {{! '<link type="text/css" rel="stylesheet" href="%s" />'%(baseurl+tmpRef+'template/'+stylesheet) if stylesheet else "" }}
+  <!-- Load MathJax 3 from the template directory -->
   <script src="{{baseurl}}{{tmpRef}}template/tex-mml-chtml.js" id="MathJax-script" async></script>
-  <script type="text/x-mathjax-config">
-  MathJax.Hub.Config({
-    tex2jax: {inlineMath: [["$","$"],["\\(","\\)"]]}
-  });
+  <!-- MathJax 3 Configuration -->
+  <script>
+  MathJax = {
+    tex: {
+      inlineMath: [['$', '$'], ['\\(', '\\)']],
+      displayMath: [['$$', '$$'], ['\\[', '\\]']]
+    },
+    svg: {
+      fontCache: 'global'
+    }
+  };
   </script>
 </head>
 <body>

--- a/reqs/tutorial/TUT017.yml
+++ b/reqs/tutorial/TUT017.yml
@@ -95,6 +95,8 @@ text: |
 
   $$k_{n+1} = n^2 + k_n^2 - k_{n-1}$$
 
+  Alternatively you can also use inline math like this: `$e=mc^2$` renders as $e=mc^2$.
+
   ### Code blocks
 
   Code blocks are either fenced by lines with three back-ticks \`\`\`. Optionally, you can add an


### PR DESCRIPTION
Fixes https://github.com/doorstop-dev/doorstop/issues/770

(This is now the correct PR based on the latest develop branch)

- updated the MathJax configuration on base.tpl to the new format.
- added an example of inline math in `TUT17.yml

Now renders correctly:
<img width="752" height="152" alt="grafik" src="https://github.com/user-attachments/assets/82b90961-89ce-4f7b-a1fc-0aa4ee1cbefa" />
