### PR TITLE
Fix heading preservation during manual reorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![Windows Tests](https://github.com/doorstop-dev/doorstop/actions/workflows/test-windows.yml/badge.svg)](https://github.com/doorstop-dev/doorstop/actions/workflows/test-windows.yml)
 <br>
 [![Coverage Status](https://img.shields.io/codecov/c/gh/doorstop-dev/doorstop)](https://codecov.io/gh/doorstop-dev/doorstop)
-[![Scrutinizer Code Quality](http://img.shields.io/scrutinizer/g/doorstop-dev/doorstop.svg)](https://scrutinizer-ci.com/g/doorstop-dev/doorstop/?branch=develop)
-[![PyPI Version](http://img.shields.io/pypi/v/Doorstop.svg)](https://pypi.org/project/Doorstop)
+[![Scrutinizer Code Quality](https://img.shields.io/scrutinizer/g/doorstop-dev/doorstop.svg)](https://scrutinizer-ci.com/g/doorstop-dev/doorstop/?branch=develop)
+[![PyPI Version](https://img.shields.io/pypi/v/Doorstop.svg)](https://pypi.org/project/Doorstop)
 <br>
 [![Gitter](https://badges.gitter.im/doorstop-dev/community.svg)](https://gitter.im/doorstop-dev/community)
 [![Google](https://img.shields.io/badge/forum-on_google-387eef)](https://groups.google.com/forum/#!forum/doorstop-dev)
@@ -12,7 +12,7 @@
 
 # Overview
 
-Doorstop is a [requirements management](http://alternativeto.net/software/doorstop/) tool that facilitates the storage of textual requirements alongside source code in version control.
+Doorstop is a [requirements management](https://alternativeto.net/software/doorstop/) tool that facilitates the storage of textual requirements alongside source code in version control.
 
 <img align="left" width="100" src="https://raw.githubusercontent.com/doorstop-dev/doorstop/develop/docs/images/logo-black-white.png"/>
 
@@ -25,7 +25,7 @@ Additional references:
 
 - Publication: [JSEA Paper](http://www.scirp.org/journal/PaperInformation.aspx?PaperID=44268#.UzYtfWRdXEZ)
 - Talks: [GRDevDay](https://speakerdeck.com/jacebrowning/doorstop-requirements-management-using-python-and-version-control), [BarCamp](https://speakerdeck.com/jacebrowning/strip-searched-a-rough-introduction-to-requirements-management)
-- Sample: [Generated HTML](http://doorstop-dev.github.io/doorstop/)
+- Sample: [Generated HTML](https://doorstop-dev.github.io/doorstop/)
 
 # Setup
 
@@ -42,7 +42,7 @@ Install Doorstop with pip:
 $ pip install doorstop
 ```
 
-or add it to your [Poetry](https://poetry.eustace.io/) project:
+or add it to your [Poetry](https://python-poetry.org/) project:
 
 ```sh
 $ poetry add doorstop

--- a/docs/cli/reordering.md
+++ b/docs/cli/reordering.md
@@ -6,8 +6,8 @@ creating headings and the subsequent items forming sub headings.
 A document can contain an arbitraty number of headings and sub headings.
 
 A normative heading item will display the item's uid as the heading text. A non normative heading
-displays the first line of the item text, with any subsequent text displayed in the body of the heading.
-
+displays the item's header as the heading text. If no header is set, the first line of the item text
+is used instead, with any subsequent text displayed in the body of the heading.
 
 # Automatic item reordering
 
@@ -26,6 +26,9 @@ Manual reordering creates an index.yml file in the document directory which desc
 of the document. The index.yml is edited, changing the indentation and order of the items to update the
 levels of each item.
 
+Existing heading items are marked in index.yml using `# HEADING #`. This preserves headings even if they
+do not have any child items.
+
 ```sh
 $ doorstop reorder --tool vi REQ
 building tree...
@@ -38,6 +41,8 @@ reordered document: REQ
 
 An item can be added by adding a new line to the index.yml containing an unknown UID, e.g. new.
 A comment following the new item ID can be used to set the item text.
+A new heading can be added by prefixing the comment with `heading #` (case insensitive); the remaining comment text is used
+as the heading header and the item is marked as non normative.
 If the line after a new item is further indented the item is treated as a heading and marked
 as non normative.
 
@@ -47,16 +52,17 @@ as non normative.
 # MANUALLY INDENT, DEDENT, & MOVE ITEMS TO THEIR DESIRED LEVEL
 # A NEW ITEM WILL BE ADDED FOR ANY UNKNOWN IDS, i.e. - new:
 # THE COMMENT WILL BE USED AS THE ITEM TEXT FOR NEW ITEMS
+# USE '# heading #' or '# HEADING #' TO MARK A NEW ITEM AS HEADING; FOLLOWING TEXT BECOMES ITS HEADER"
 # CHANGES WILL BE REFLECTED IN THE ITEM FILES AFTER CONFIRMATION
 ###############################################################################
 
 initial: 1.0
 outline:
-    - REQ018: # Overview
+    - REQ018: # HEADING # Overview
         - REQ019: # Doorstop is a requirements management tool that leverage...
         - NEW: # The text of a new item
-    - NEW: # A new heading
-        - NEW: # The text of a new ite,
+    - NEW: # heading # A new heading
+        - NEW: # The text of a new item
 ```
 
 ## Deleting an item

--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -613,36 +613,81 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         yield "# MANUALLY INDENT, DEDENT, & MOVE ITEMS TO THEIR DESIRED LEVEL"
         yield "# A NEW ITEM WILL BE ADDED FOR ANY UNKNOWN IDS, i.e. - new: "
         yield "# THE COMMENT WILL BE USED AS THE ITEM TEXT FOR NEW ITEMS"
+        yield "# USE '# heading #' or '# HEADING #' TO MARK A NEW ITEM AS HEADING; FOLLOWING TEXT BECOMES ITS HEADER"
         yield "# CHANGES WILL BE REFLECTED IN THE ITEM FILES AFTER CONFIRMATION"
         yield "#" * settings.MAX_LINE_LENGTH
         yield ""
         yield "initial: {}".format(items[0].level if items else 1.0)
         yield "outline:"
+
         for item in items:
             space = "    " * item.depth
-            lines = item.text.strip().splitlines()
-            comment = lines[0].replace("\\", "\\\\") if lines else ""
+
+            # Determine comment text: prefer header, fall back to text
+            header_lines = item.header.strip().splitlines() if item.header else []
+            text_lines = item.text.strip().splitlines() if item.text else []
+
+            if header_lines:
+                comment = header_lines[0].replace("\\", "\\\\")
+            elif text_lines:
+                comment = text_lines[0].replace("\\", "\\\\")
+            else:
+                comment = ""
+
+            # Prepend the heading marker for heading items
+            if item.heading:
+                comment = "HEADING # {}".format(comment) if comment else "HEADING #"
+
             line = space + "- {u}: # {c}".format(u=item.uid, c=comment)
+
             if len(line) > settings.MAX_LINE_LENGTH:
                 line = line[: settings.MAX_LINE_LENGTH - 3] + "..."
+
             yield line
 
     @staticmethod
     def _read_index(path):
-        """Load the index, converting comments to text entries for each item."""
+        """Load the index, converting comments to text or heading entries."""
         with open(path, "r", encoding="utf-8") as stream:
             text = stream.read()
+
         yaml_text = []
+
         for line in text.split("\n"):
-            m = re.search(r"(\s+)(- [\w\d-]+\s*): # (.+)$", line)
+            m = re.search(r"(\s*)(- [\w\d-]+\s*):\s*#\s*(.*)$", line)
             if m:
                 prefix = m.group(1)
                 uid = m.group(2)
-                item_text = m.group(3).replace('"', '\\"')
+                uid = m.group(2)
+                comment = m.group(3)
+
+                # Preserve old behavior:
+                # "- REQ001: #" without comment text is not converted into a
+                # text or heading entry. Whether it becomes a heading is decided
+                # later based on the presence of child elements.
+                if not comment.strip():
+                    yaml_text.append(line)
+                    continue
+
+                heading_match = re.match(r"heading\s*#\s*(.*)$", comment, re.IGNORECASE)
+
                 yaml_text.append("{p}{u}:".format(p=prefix, u=uid))
-                yaml_text.append('    {p}- text: "{t}"'.format(p=prefix, t=item_text))
+
+                if heading_match:
+                    # Heading marker: extract header text after "heading #"
+                    header_text = heading_match.group(1).strip().replace('"', '\\"')
+                    yaml_text.append(
+                        '    {p}- header: "{t}"'.format(p=prefix, t=header_text)
+                    )
+                else:
+                    # Normal item: text entry as before
+                    item_text = comment.replace('"', '\\"')
+                    yaml_text.append(
+                        '    {p}- text: "{t}"'.format(p=prefix, t=item_text)
+                    )
             else:
                 yaml_text.append(line)
+
         return common.load_yaml("\n".join(yaml_text), path)
 
     @staticmethod
@@ -666,8 +711,8 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         """Recursive function to reorder a section of an outline.
 
         :param section: recursive `list` of `dict` loaded from document index
-        :param level: current :class:`~doorstop.core.types.Level`
-        :param document: :class:`~doorstop.core.document.Document` to order
+        :param level: current :class`~doorstop.core.types.Level`
+        :param document: :class`~doorstop.core.document.Document` to order
 
         """
         if isinstance(section, dict):  # a section
@@ -677,31 +722,43 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
                 return
             subsection = section[uid]
 
-            # An item is a header if it has a subsection
             level.heading = False
             item_text = ""
+            item_header = ""
             if isinstance(subsection, str):
                 item_text = subsection
             elif isinstance(subsection, list):
-                if "text" in subsection[0]:
+                if "header" in subsection[0]:
+                    # Item is marked as heading in index, extract header text
+                    item_header = subsection[0]["header"]
+                    level.heading = True
+                    subsection = subsection[1:]  # remove heading entry from subsection
+                elif "text" in subsection[0]:
+                    # Extract text for new non-heading items
                     item_text = subsection[0]["text"]
-                    if len(subsection) > 1:
-                        level.heading = True
+                    subsection = subsection[1:]  # remove text entry from subsection
+                # Item is a heading if it has child elements
+                if len(subsection) > 0:
+                    level.heading = True
 
             try:
                 item = document.find_item(uid)
+                # Existing item: only update level, leave content untouched
                 item.level = level
                 log.info("Found ({}): {}".format(uid, level))
                 list_of_ids.append(uid)
             except DoorstopError:
+                # New item: set level and content
                 item = document.add_item(level=level, reorder=False)
                 list_of_ids.append(item.uid)
                 if level.heading:
                     item.normative = False
-                item.text = item_text
+                    item.header = item_header
+                else:
+                    item.text = item_text
                 log.info("Created ({}): {}".format(item.uid, level))
 
-            # Process the heading's subsection
+            # Process the subsection recursively
             if subsection:
                 Document._reorder_section(subsection, level >> 1, document, list_of_ids)
 

--- a/doorstop/core/publishers/tests/test_publisher_html.py
+++ b/doorstop/core/publishers/tests/test_publisher_html.py
@@ -325,6 +325,7 @@ class TestTableOfContents(unittest.TestCase):
             {"depth": 2, "text": "1.6 Hello, world! (REQ004)", "uid": ""},
             {"depth": 2, "text": "2.1 Plantuml (REQ002)", "uid": ""},
             {"depth": 2, "text": "2.1 Hello, world! (REQ2-001)", "uid": ""},
+            {"depth": 1, "text": "3.0 My Heading", "uid": ""},
         ]
         html_publisher = publisher.check(".html", self.document)
         toc = html_publisher.table_of_contents(linkify=None, obj=self.document)
@@ -345,6 +346,7 @@ class TestTableOfContents(unittest.TestCase):
             {"depth": 2, "text": "Hello, world! (REQ004)", "uid": ""},
             {"depth": 2, "text": "Plantuml (REQ002)", "uid": ""},
             {"depth": 2, "text": "Hello, world! (REQ2-001)", "uid": ""},
+            {"depth": 1, "text": "My Heading", "uid": ""},
         ]
 
         html_publisher = publisher.check(".html", self.document)
@@ -373,6 +375,7 @@ class TestTableOfContents(unittest.TestCase):
                 "text": "2.1 Hello, world! (REQ2-001)",
                 "uid": UID("REQ2-001"),
             },
+            {"depth": 1, "text": "3.0 My Heading", "uid": UID("REQ007")},
         ]
         html_publisher = publisher.check(".html", self.document)
         toc = html_publisher.table_of_contents(linkify=True, obj=self.document)

--- a/doorstop/core/publishers/tests/test_publisher_markdown.py
+++ b/doorstop/core/publishers/tests/test_publisher_markdown.py
@@ -230,7 +230,8 @@ class TestTableOfContents(unittest.TestCase):
     * 1.5 Hello, world! (REQ006)
     * 1.6 Hello, world! (REQ004)
     * 2.1 Plantuml (REQ002)
-    * 2.1 Hello, world! (REQ2-001)\n"""
+    * 2.1 Hello, world! (REQ2-001)
+ * 3.0 My Heading\n"""
         md_publisher = publisher.check(".md", self.document)
         toc = md_publisher.table_of_contents(linkify=None, obj=self.document)
         self.assertEqual(expected, toc)
@@ -246,6 +247,7 @@ class TestTableOfContents(unittest.TestCase):
     * Hello, world! (REQ004)
     * Plantuml (REQ002)
     * Hello, world! (REQ2-001)
+ * My Heading
 """
         md_publisher = publisher.check(".md", self.document)
         toc = md_publisher.table_of_contents(linkify=None, obj=self.document)
@@ -260,7 +262,8 @@ class TestTableOfContents(unittest.TestCase):
     * [1.5 Hello, world! (REQ006)](#15-req006-req006)
     * [1.6 Hello, world! (REQ004)](#16-req004-req004)
     * [2.1 Plantuml (REQ002)](#21-plantuml-req002-req002)
-    * [2.1 Hello, world! (REQ2-001)](#21-req2-001-req2-001)\n"""
+    * [2.1 Hello, world! (REQ2-001)](#21-req2-001-req2-001)
+ * [3.0 My Heading](#30-my-heading-req007)\n"""
         self.maxDiff = None
         md_publisher = publisher.check(".md", self.document)
         toc = md_publisher.table_of_contents(linkify=True, obj=self.document)

--- a/doorstop/core/tests/__init__.py
+++ b/doorstop/core/tests/__init__.py
@@ -17,6 +17,19 @@ ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "..")
 
 TESTS_ROOT = os.path.dirname(__file__)
 FILES = os.path.join(os.path.dirname(__file__), "files")
+# Files that use the golden master pattern and are intentionally
+# updated by tests - these should not be reset after each test run
+GOLDEN_MASTER_FILES = {
+    os.path.join(FILES, "exported.yml"),
+    os.path.join(FILES, "exported.csv"),
+    os.path.join(FILES, "exported.tsv"),
+    os.path.join(FILES, "published.html"),
+    os.path.join(FILES, "published.md"),
+    os.path.join(FILES, "published.txt"),
+    os.path.join(FILES, "published2.html"),
+    os.path.join(FILES, "published2.md"),
+    os.path.join(FILES, "published2.txt"),
+}
 FILES_MD = os.path.join(os.path.dirname(__file__), "files_md")
 SYS = os.path.join(FILES, "parent")
 TST = os.path.join(FILES, "child")

--- a/doorstop/core/tests/files/REQ007.yml
+++ b/doorstop/core/tests/files/REQ007.yml
@@ -1,0 +1,10 @@
+active: true
+derived: false
+header: |
+  My Heading
+level: 3.0
+links: []
+normative: false
+ref: ''
+reviewed: null
+text: ''

--- a/doorstop/core/tests/files/exported.csv
+++ b/doorstop/core/tests/files/exported.csv
@@ -38,3 +38,4 @@ Test Math Expressions in Latex Style:
 Inline Style 1: $a \ne 0$
 Inline Style 2: \(ax^2 + bx + c = 0\)
 Multiline: $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$",,,REQ001,True,False,,True,
+REQ007,3.0,,,,,True,False,My Heading,False,

--- a/doorstop/core/tests/files/exported.tsv
+++ b/doorstop/core/tests/files/exported.tsv
@@ -38,3 +38,4 @@ Test Math Expressions in Latex Style:
 Inline Style 1: $a \ne 0$
 Inline Style 2: \(ax^2 + bx + c = 0\)
 Multiline: $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$"			REQ001	True	False		True	
+REQ007	3.0					True	False	My Heading	False	

--- a/doorstop/core/tests/files/exported.yml
+++ b/doorstop/core/tests/files/exported.yml
@@ -113,3 +113,15 @@ REQ2-001:
     Inline Style 2: \(ax^2 + bx + c = 0\)
     Multiline: $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
 
+REQ007:
+  active: true
+  derived: false
+  header: |
+    My Heading
+  level: 3.0
+  links: []
+  normative: false
+  ref: ''
+  reviewed: null
+  text: ''
+

--- a/doorstop/core/tests/files/published.html
+++ b/doorstop/core/tests/files/published.html
@@ -90,7 +90,14 @@
                     data-bs-placement="left"
                     title="REQ2-001">2.1 Hello, world! (REQ2-001)</a>
                 </li>
-                </ul>
+                    </ul>
+                <li>
+                  <a class="dropdown-item text-truncate"
+                    href="#REQ007"
+                    data-bs-toggle="tooltip"
+                    data-bs-placement="left"
+                    title="REQ007">3.0 My Heading</a>
+                </li>
                 </ul>
             </ul>
           </li>
@@ -186,6 +193,7 @@ Inline Style 2: (ax^2 + bx + c = 0)
 Multiline: $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$</p>
 <p><em>Parent links:</em> <a href="REQ.html#REQ001">REQ001</a></p>
 <p><em>Child links:</em> <a href="TST.html#TST001">TST001</a></p>
+<h1 id="REQ007">3.0 My Heading</h1>
     </div>
   </main>
 </div>

--- a/doorstop/core/tests/files/published.md
+++ b/doorstop/core/tests/files/published.md
@@ -70,3 +70,5 @@ Multiline: $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
 
 *Child links: TST001*
 
+# 3.0 My Heading {#REQ007}
+

--- a/doorstop/core/tests/files/published.txt
+++ b/doorstop/core/tests/files/published.txt
@@ -73,3 +73,5 @@
 
         Child links: TST001
 
+3.0     My Heading
+

--- a/doorstop/core/tests/files/published2.html
+++ b/doorstop/core/tests/files/published2.html
@@ -90,7 +90,14 @@
                     data-bs-placement="left"
                     title="REQ2-001">2.1 Hello, world! (REQ2-001)</a>
                 </li>
-                </ul>
+                    </ul>
+                <li>
+                  <a class="dropdown-item text-truncate"
+                    href="#REQ007"
+                    data-bs-toggle="tooltip"
+                    data-bs-placement="left"
+                    title="REQ007">3.0 My Heading</a>
+                </li>
                 </ul>
             </ul>
           </li>
@@ -184,6 +191,7 @@ System --&gt; (Integrity)
 Inline Style 2: (ax^2 + bx + c = 0)
 Multiline: $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$</p>
 <p><em>Links: REQ001</em></p>
+<h1 id="REQ007">3.0 My Heading</h1>
     </div>
   </main>
 </div>

--- a/doorstop/core/tests/files/published2.md
+++ b/doorstop/core/tests/files/published2.md
@@ -66,3 +66,5 @@ Multiline: $$x = {-b \pm \sqrt{b^2-4ac} \over 2a}.$$
 
 *Links: REQ001*
 
+# 3.0 My Heading {#REQ007}
+

--- a/doorstop/core/tests/files/published2.txt
+++ b/doorstop/core/tests/files/published2.txt
@@ -69,3 +69,5 @@
 
         Links: REQ001
 
+3.0     My Heading
+

--- a/doorstop/core/tests/test_all.py
+++ b/doorstop/core/tests/test_all.py
@@ -28,6 +28,7 @@ from doorstop.core.tests import (
     ENV,
     FILES,
     FILES_MD,
+    GOLDEN_MASTER_FILES,
     REASON,
     ROOT,
     SYS,
@@ -76,6 +77,17 @@ def cleanup_test_yml_files():
 
             if result.returncode == 0 and result.stdout.strip():
                 yaml_files = result.stdout.strip().split("\n")
+
+                # Exclude golden master files from reset
+                yaml_files = [
+                    f
+                    for f in yaml_files
+                    if os.path.abspath(os.path.join(repo_root, f))
+                    not in GOLDEN_MASTER_FILES
+                ]
+
+                if not yaml_files:
+                    continue
 
                 # Reset only these YAML files
                 subprocess.run(
@@ -215,7 +227,7 @@ class TestDocument(unittest.TestCase):
         self.assertEqual("REQ", doc.prefix)
         self.assertEqual("yaml", doc.itemformat)
         self.assertEqual(2, doc.digits)
-        self.assertEqual(6, len(doc.items))
+        self.assertEqual(7, len(doc.items))
 
     def test_new(self):
         """Verify a new document can be created."""
@@ -238,7 +250,7 @@ class TestDocument(unittest.TestCase):
         issues = self.document.issues
         for issue in self.document.issues:
             logging.info(repr(issue))
-        self.assertEqual(13, len(issues))
+        self.assertEqual(15, len(issues))
 
     @patch("doorstop.settings.REORDER", False)
     @patch("doorstop.settings.REVIEW_NEW_ITEMS", False)
@@ -394,7 +406,7 @@ class TestTree(unittest.TestCase):
         issues = self.tree.issues
         for issue in self.tree.issues:
             logging.info(repr(issue))
-        self.assertEqual(15, len(issues))
+        self.assertEqual(17, len(issues))
 
     @patch("doorstop.settings.REORDER", False)
     @patch("doorstop.settings.REVIEW_NEW_ITEMS", False)
@@ -600,8 +612,13 @@ class TestExporter(unittest.TestCase):
         # Assert
         self.assertIs(temp, path2)
         actual = read_yml(temp)
+        # Assert
+        if actual != expected:
+            common.log.error(f"Published content changed: {path}")
+            move_file(temp, path)
+        else:
+            common.delete(temp)  # clean up in case the file didn't change
         self.assertEqual(expected, actual)
-        move_file(temp, path)
 
     def test_export_csv(self):
         """Verify a document can be exported as a CSV file."""
@@ -613,8 +630,13 @@ class TestExporter(unittest.TestCase):
         # Assert
         self.assertIs(temp, path2)
         actual = read_csv(temp)
+        # Assert
+        if actual != expected:
+            common.log.error(f"Published content changed: {path}")
+            move_file(temp, path)
+        else:
+            common.delete(temp)  # clean up in case the file didn't change
         self.assertEqual(expected, actual)
-        move_file(temp, path)
 
     @patch("doorstop.settings.REVIEW_NEW_ITEMS", False)
     def test_export_tsv(self):
@@ -627,8 +649,13 @@ class TestExporter(unittest.TestCase):
         # Assert
         self.assertIs(temp, path2)
         actual = read_csv(temp, delimiter="\t")
+        # Assert
+        if actual != expected:
+            common.log.error(f"Published content changed: {path}")
+            move_file(temp, path)
+        else:
+            common.delete(temp)  # clean up in case the file didn't change
         self.assertEqual(expected, actual)
-        move_file(temp, path)
 
 
 class TestPublisher(unittest.TestCase):
@@ -684,8 +711,10 @@ class TestPublisher(unittest.TestCase):
         lines = core.publisher.publish_lines(self.document, ".txt")
         text = "".join(line + "\n" for line in lines)
         # Assert
+        if text != expected:
+            common.log.error(f"Published content changed: {path}")
+            common.write_text(text, path)
         self.assertEqual(expected, text)
-        common.write_text(text, path)
 
     @patch("doorstop.settings.PUBLISH_CHILD_LINKS", False)
     def test_lines_text_document_without_child_links(self):
@@ -696,8 +725,10 @@ class TestPublisher(unittest.TestCase):
         lines = core.publisher.publish_lines(self.document, ".txt")
         text = "".join(line + "\n" for line in lines)
         # Assert
+        if text != expected:
+            common.log.error(f"Published content changed: {path}")
+            common.write_text(text, path)
         self.assertEqual(expected, text)
-        common.write_text(text, path)
 
     def test_lines_markdown_document(self):
         """Verify Markdown can be published from a document."""
@@ -709,7 +740,7 @@ class TestPublisher(unittest.TestCase):
         # Assert
         if text != expected:
             common.log.error(f"Published content changed: {path}")
-        common.write_text(text, path)
+            common.write_text(text, path)
         self.assertEqual(expected, text)
 
     @patch("doorstop.settings.PUBLISH_CHILD_LINKS", False)
@@ -723,7 +754,7 @@ class TestPublisher(unittest.TestCase):
         # Assert
         if text != expected:
             common.log.error(f"Published content changed: {path}")
-        common.write_text(text, path)
+            common.write_text(text, path)
         self.assertEqual(expected, text)
 
     @patch("plantuml_markdown.PlantUMLPreprocessor.run")
@@ -751,7 +782,7 @@ class TestPublisher(unittest.TestCase):
         # Assert
         if actual != expected:
             common.log.error(f"Published content changed: {path}")
-        common.write_text(actual, path)
+            common.write_text(actual, path)
         self.assertEqual(expected, actual)
 
     @patch("plantuml_markdown.PlantUMLPreprocessor.run")
@@ -776,7 +807,7 @@ class TestPublisher(unittest.TestCase):
         # Assert
         if actual != expected:
             common.log.error(f"Published content changed: {path}")
-        common.write_text(actual, path)
+            common.write_text(actual, path)
         self.assertEqual(expected, actual)
 
 

--- a/doorstop/core/tests/test_document.py
+++ b/doorstop/core/tests/test_document.py
@@ -407,14 +407,14 @@ class TestDocument(unittest.TestCase):
             "        - REQ003: # Unicode: -40° ±1%",
             "        - REQ006: # Hello, world!",
             "        - REQ004: # Hello, world!",
-            "        - REQ002: # Hello, world!",
+            "        - REQ002: # Plantuml",
             "        - REQ2-001: # Hello, world!",
         ]
         # Act
         self.document.index = True  # create index
         # Assert
         gen, path = mock_write_lines.call_args[0]
-        lines2 = list(gen)[8:]  # skip lines of info comments
+        lines2 = list(gen)[9:]  # skip lines of info comments
         self.assertListEqual(lines, lines2)
         self.assertEqual(os.path.join(FILES, "index.yml"), path)
 
@@ -896,6 +896,137 @@ outline:
         # Assert
         self.assertEqual([], mock_copytree.call_args_list)
 
+    def test_lines_index_writes_heading_marker(self):
+        """Verify heading items are marked with '# HEADING #' in the index."""
+
+        class IndexItem:
+            def __init__(self, uid, level, depth, header, text, heading):
+                self.uid = uid
+                self.level = Level(level)
+                self.depth = depth
+                self.header = header
+                self.text = text
+                self.heading = heading
+
+        items = [
+            IndexItem(
+                uid="REQ001",
+                level="1.0",
+                depth=0,
+                header="My Heading",
+                text="Fallback text",
+                heading=True,
+            ),
+            IndexItem(
+                uid="REQ002",
+                level="2",
+                depth=0,
+                header="Requirement Header",
+                text="Requirement text",
+                heading=False,
+            ),
+            IndexItem(
+                uid="REQ003",
+                level="3",
+                depth=0,
+                header="",
+                text="Requirement text",
+                heading=False,
+            ),
+        ]
+
+        lines = list(Document._lines_index(items))
+
+        self.assertIn("- REQ001: # HEADING # My Heading", lines)
+        self.assertIn("- REQ002: # Requirement Header", lines)
+        self.assertIn("- REQ003: # Requirement text", lines)
+
+    def test_read_index_converts_heading_marker(self):
+        """Verify '# HEADING #' comments are converted to heading entries."""
+        lines = """initial: 1.2.3
+outline:
+    - REQ001: # HEADING # My Heading"""
+
+        expected = {
+            "initial": "1.2.3",
+            "outline": [
+                {"REQ001": [{"header": "My Heading"}]},
+            ],
+        }
+
+        with patch("builtins.open", mock.mock_open(read_data=lines)):
+            actual = self.document._read_index("mock_path")
+
+        self.assertEqual(expected, actual)
+
+    def test_read_index_converts_heading_marker_with_whitespace(self):
+        """Verify heading markers tolerate additional whitespace."""
+        lines = """initial: 1.2.3
+outline:
+    - REQ001: #     heading      #     My Heading"""
+
+        expected = {
+            "initial": "1.2.3",
+            "outline": [
+                {"REQ001": [{"header": "My Heading"}]},
+            ],
+        }
+
+        with patch("builtins.open", mock.mock_open(read_data=lines)):
+            actual = self.document._read_index("mock_path")
+
+        self.assertEqual(expected, actual)
+
+    def test_read_index_preserves_empty_comment(self):
+        """Verify empty comments are not converted to text or heading entries."""
+        lines = """initial: 1.2.3
+outline:
+    - REQ001: #"""
+
+        expected = {
+            "initial": "1.2.3",
+            "outline": [
+                {"REQ001": None},
+            ],
+        }
+
+        with patch("builtins.open", mock.mock_open(read_data=lines)):
+            actual = self.document._read_index("mock_path")
+
+        self.assertEqual(expected, actual)
+
+
+class ReorderItem:
+    """Simple item fake for _reorder_section tests."""
+
+    def __init__(self, uid="REQ999", level=None):
+        self.uid = uid
+        self.level = level
+        self.text = ""
+        self.header = ""
+        self.normative = True
+
+
+class ReorderDocument:
+    """Simple document fake for _reorder_section tests."""
+
+    def __init__(self, existing=None):
+        self.existing = existing or {}
+        self.added = []
+
+    def find_item(self, uid):
+        if uid in self.existing:
+            return self.existing[uid]
+        raise DoorstopError(uid)
+
+    def add_item(self, level=None, reorder=False):  # pylint: disable=unused-argument
+        item = ReorderItem(
+            uid="REQ999",
+            level=level.copy() if level else None,
+        )
+        self.added.append(item)
+        return item
+
 
 @patch("doorstop.core.item.Item", MockItem)
 class TestDocumentReorder(unittest.TestCase):
@@ -1057,3 +1188,88 @@ class TestDocumentReorder(unittest.TestCase):
         actual = [item.level for item in items]
         self.assertListEqual(expected, actual)
         self.assertEqual(mock_item.method_calls, [call.delete()])
+
+    def test_reorder_section_creates_new_heading_without_children(self):
+        """Verify a new heading item can be created without child items."""
+        document = ReorderDocument()
+        ids = []
+
+        section = {
+            "NEW": [
+                {"header": "New Heading with a Header"},
+            ]
+        }
+
+        Document._reorder_section(section, Level("1"), document, ids)
+
+        self.assertEqual(1, len(document.added))
+
+        item = document.added[0]
+        self.assertTrue(item.level.heading)
+        self.assertEqual("1.0", str(item.level))
+        self.assertFalse(item.normative)
+        self.assertEqual("New Heading with a Header", item.header)
+        self.assertEqual("", item.text)
+
+    def test_reorder_section_creates_new_requirement_with_text(self):
+        """Verify a new non-heading item gets its text from the index comment."""
+        document = ReorderDocument()
+        ids = []
+
+        section = {
+            "NEW": [
+                {"text": "New requirement text"},
+            ]
+        }
+
+        Document._reorder_section(section, Level("1"), document, ids)
+
+        self.assertEqual(1, len(document.added))
+
+        item = document.added[0]
+        self.assertFalse(item.level.heading)
+
+    def test_reorder_section_existing_item_keeps_content(self):
+        """Verify existing items keep their content during manual reorder."""
+        item = ReorderItem(uid="REQ001", level=Level("1"))
+        item.header = "Existing Header"
+        item.text = "Existing Text"
+        item.normative = False
+
+        document = ReorderDocument(existing={"REQ001": item})
+        ids = []
+
+        section = {
+            "REQ001": [
+                {"heading": "Changed Header From Index"},
+            ]
+        }
+
+        Document._reorder_section(section, Level("2"), document, ids)
+
+    def test_reorder_section_sets_heading_when_children_exist(self):
+        """Verify an item with direct child elements is treated as a heading."""
+        document = ReorderDocument()
+        ids = []
+
+        section = {
+            "NEW": [
+                {"DOC-001": [{"text": "Child requirement"}]},
+            ]
+        }
+
+        Document._reorder_section(section, Level("1"), document, ids)
+
+        self.assertEqual(2, len(document.added))
+
+        parent = document.added[0]
+        child = document.added[1]
+
+        self.assertTrue(parent.level.heading)
+        self.assertEqual("1.0", str(parent.level))
+        self.assertFalse(parent.normative)
+
+        self.assertFalse(child.level.heading)
+        self.assertEqual("1.1", str(child.level))
+        self.assertTrue(child.normative)
+        self.assertEqual("Child requirement", child.text)

--- a/doorstop/core/tests/test_document.py
+++ b/doorstop/core/tests/test_document.py
@@ -297,12 +297,12 @@ class TestDocument(unittest.TestCase):
 
     def test_len(self):
         """Verify a document has a length."""
-        self.assertEqual(6, len(self.document))
+        self.assertEqual(7, len(self.document))
 
     def test_items(self):
         """Verify the items in a document can be accessed."""
         items = self.document.items
-        self.assertEqual(6, len(items))
+        self.assertEqual(7, len(items))
         for item in self.document:
             logging.debug("item: {}".format(item))
             self.assertIs(self.document, item.document)
@@ -313,7 +313,7 @@ class TestDocument(unittest.TestCase):
         self.document.tree = Mock()
         self.document.tree._item_cache = {}
         print(self.document.items)
-        self.assertEqual(7, len(self.document.tree._item_cache))
+        self.assertEqual(8, len(self.document.tree._item_cache))
 
     @patch("doorstop.core.document.Document", MockDocument)
     def test_new(self):
@@ -381,7 +381,7 @@ class TestDocument(unittest.TestCase):
 
     def test_next_number(self):
         """Verify the next item number can be determined."""
-        self.assertEqual(7, self.document.next_number)
+        self.assertEqual(8, self.document.next_number)
 
     def test_next_number_server(self):
         """Verify the next item number can be determined with a server."""
@@ -395,28 +395,6 @@ class TestDocument(unittest.TestCase):
         with patch("os.path.isfile", Mock(return_value=True)):
             path = os.path.join(self.document.path, self.document.INDEX)
             self.assertEqual(path, self.document.index)
-
-    @patch("doorstop.common.write_lines")
-    @patch("doorstop.settings.MAX_LINE_LENGTH", 40)
-    def test_index_set(self, mock_write_lines):
-        """Verify an document's index can be created."""
-        lines = [
-            "initial: 1.2.3",
-            "outline:",
-            "            - REQ001: # Lorem ipsum d...",
-            "        - REQ003: # Unicode: -40° ±1%",
-            "        - REQ006: # Hello, world!",
-            "        - REQ004: # Hello, world!",
-            "        - REQ002: # Hello, world!",
-            "        - REQ2-001: # Hello, world!",
-        ]
-        # Act
-        self.document.index = True  # create index
-        # Assert
-        gen, path = mock_write_lines.call_args[0]
-        lines2 = list(gen)[8:]  # skip lines of info comments
-        self.assertListEqual(lines, lines2)
-        self.assertEqual(os.path.join(FILES, "index.yml"), path)
 
     @patch("doorstop.common.write_lines")
     @patch("doorstop.settings.MAX_LINE_LENGTH", 40)
@@ -450,6 +428,29 @@ outline:
         # Assert
         self.assertEqual(expected, actual)
 
+    @patch("doorstop.common.write_lines")
+    @patch("doorstop.settings.MAX_LINE_LENGTH", 40)
+    def test_index_set(self, mock_write_lines):
+        """Verify an document's index can be created."""
+        lines = [
+            "initial: 1.2.3",
+            "outline:",
+            "            - REQ001: # Lorem ipsum d...",
+            "        - REQ003: # Unicode: -40° ±1%",
+            "        - REQ006: # Hello, world!",
+            "        - REQ004: # Hello, world!",
+            "        - REQ002: # Hello, world!",
+            "        - REQ2-001: # Hello, world!",
+            "    - REQ007: # ",
+        ]
+        # Act
+        self.document.index = True  # create index
+        # Assert
+        gen, path = mock_write_lines.call_args[0]
+        lines2 = list(gen)[8:]  # skip lines of info comments
+        self.assertListEqual(lines, lines2)
+        self.assertEqual(os.path.join(FILES, "index.yml"), path)
+
     @patch("doorstop.common.delete")
     def test_index_del(self, mock_delete):
         """Verify a document's index can be deleted."""
@@ -463,7 +464,7 @@ outline:
         with patch("doorstop.settings.REORDER", True):
             self.document.add_item()
         mock_new.assert_called_once_with(
-            None, self.document, FILES, ROOT, "REQ007", level=Level("2.2")
+            None, self.document, FILES, ROOT, "REQ008", level=Level("3.1")
         )
         self.assertEqual(0, mock_reorder.call_count)
 
@@ -474,7 +475,7 @@ outline:
         with patch("doorstop.settings.REORDER", True):
             item = self.document.add_item(level="4.2")
         mock_new.assert_called_once_with(
-            None, self.document, FILES, ROOT, "REQ007", level="4.2"
+            None, self.document, FILES, ROOT, "REQ008", level="4.2"
         )
         mock_reorder.assert_called_once_with(keep=item)
 
@@ -483,7 +484,7 @@ outline:
         """Verify an item can be added to a document with a number."""
         self.document.add_item(number=999)
         mock_new.assert_called_once_with(
-            None, self.document, FILES, ROOT, "REQ999", level=Level("2.2")
+            None, self.document, FILES, ROOT, "REQ999", level=Level("3.1")
         )
 
     def test_add_item_with_no_sep(self):
@@ -515,7 +516,7 @@ outline:
         self.document.sep = "-"
         self.document.add_item(name="ABC")
         mock_new.assert_called_once_with(
-            None, self.document, FILES, ROOT, "REQ-ABC", level=Level("2.2")
+            None, self.document, FILES, ROOT, "REQ-ABC", level=Level("3.1")
         )
 
     @patch("doorstop.core.item.Item.new")
@@ -524,7 +525,7 @@ outline:
         self.document.sep = "-"
         self.document.add_item(name="99")
         mock_new.assert_called_once_with(
-            None, self.document, FILES, ROOT, "REQ-099", level=Level("2.2")
+            None, self.document, FILES, ROOT, "REQ-099", level=Level("3.1")
         )
 
     @patch("doorstop.core.item.Item.set_attributes")
@@ -729,7 +730,7 @@ outline:
         with patch("doorstop.settings.REORDER", True):
             self.assertTrue(self.document.validate())
         mock_reorder.assert_called_once_with(_items=self.document.items)
-        self.assertEqual(6, mock_get_issues.call_count)
+        self.assertEqual(7, mock_get_issues.call_count)
 
     @patch(
         "doorstop.core.validators.item_validator.ItemValidator.get_issues",
@@ -753,14 +754,14 @@ outline:
         """Verify an item hook can be called."""
         mock_hook = MagicMock()
         self.document.validate(item_hook=mock_hook)
-        self.assertEqual(6, mock_hook.call_count)
+        self.assertEqual(7, mock_hook.call_count)
 
     @patch("doorstop.core.item.Item.delete")
     @patch("os.rmdir")
     def test_delete(self, mock_delete, mock_item_delete):
         """Verify a document can be deleted."""
         self.document.delete()
-        self.assertEqual(7, mock_item_delete.call_count)
+        self.assertEqual(8, mock_item_delete.call_count)
         self.assertEqual(1, mock_delete.call_count)
         self.document.delete()  # ensure a second delete is ignored
 
@@ -770,7 +771,7 @@ outline:
         """Verify a document's assets aren't deleted."""
         mock_delete.side_effect = OSError
         self.document.delete()
-        self.assertEqual(7, mock_item_delete.call_count)
+        self.assertEqual(8, mock_item_delete.call_count)
         self.assertEqual(1, mock_delete.call_count)
         self.document.delete()  # ensure a second delete is ignored
 

--- a/doorstop/core/tests/test_document.py
+++ b/doorstop/core/tests/test_document.py
@@ -398,6 +398,29 @@ class TestDocument(unittest.TestCase):
 
     @patch("doorstop.common.write_lines")
     @patch("doorstop.settings.MAX_LINE_LENGTH", 40)
+    def test_index_set(self, mock_write_lines):
+        """Verify an document's index can be created."""
+        lines = [
+            "initial: 1.2.3",
+            "outline:",
+            "            - REQ001: # Lorem ipsum d...",
+            "        - REQ003: # Unicode: -40° ±1%",
+            "        - REQ006: # Hello, world!",
+            "        - REQ004: # Hello, world!",
+            "        - REQ002: # Plantuml",
+            "        - REQ2-001: # Hello, world!",
+            "    - REQ007: # HEADING # My Heading",
+        ]
+        # Act
+        self.document.index = True  # create index
+        # Assert
+        gen, path = mock_write_lines.call_args[0]
+        lines2 = list(gen)[9:]  # skip lines of info comments
+        self.assertListEqual(lines, lines2)
+        self.assertEqual(os.path.join(FILES, "index.yml"), path)
+
+    @patch("doorstop.common.write_lines")
+    @patch("doorstop.settings.MAX_LINE_LENGTH", 40)
     def test_read_index(self, mock_write_lines):
         """Verify a document index can be read."""
         lines = """initial: 1.2.3
@@ -427,29 +450,6 @@ outline:
             # Check string can be parsed as yaml
         # Assert
         self.assertEqual(expected, actual)
-
-    @patch("doorstop.common.write_lines")
-    @patch("doorstop.settings.MAX_LINE_LENGTH", 40)
-    def test_index_set(self, mock_write_lines):
-        """Verify an document's index can be created."""
-        lines = [
-            "initial: 1.2.3",
-            "outline:",
-            "            - REQ001: # Lorem ipsum d...",
-            "        - REQ003: # Unicode: -40° ±1%",
-            "        - REQ006: # Hello, world!",
-            "        - REQ004: # Hello, world!",
-            "        - REQ002: # Hello, world!",
-            "        - REQ2-001: # Hello, world!",
-            "    - REQ007: # ",
-        ]
-        # Act
-        self.document.index = True  # create index
-        # Assert
-        gen, path = mock_write_lines.call_args[0]
-        lines2 = list(gen)[8:]  # skip lines of info comments
-        self.assertListEqual(lines, lines2)
-        self.assertEqual(os.path.join(FILES, "index.yml"), path)
 
     @patch("doorstop.common.delete")
     def test_index_del(self, mock_delete):
@@ -897,6 +897,137 @@ outline:
         # Assert
         self.assertEqual([], mock_copytree.call_args_list)
 
+    def test_lines_index_writes_heading_marker(self):
+        """Verify heading items are marked with '# HEADING #' in the index."""
+
+        class IndexItem:
+            def __init__(self, uid, level, depth, header, text, heading):
+                self.uid = uid
+                self.level = Level(level)
+                self.depth = depth
+                self.header = header
+                self.text = text
+                self.heading = heading
+
+        items = [
+            IndexItem(
+                uid="REQ001",
+                level="1.0",
+                depth=0,
+                header="My Heading",
+                text="Fallback text",
+                heading=True,
+            ),
+            IndexItem(
+                uid="REQ002",
+                level="2",
+                depth=0,
+                header="Requirement Header",
+                text="Requirement text",
+                heading=False,
+            ),
+            IndexItem(
+                uid="REQ003",
+                level="3",
+                depth=0,
+                header="",
+                text="Requirement text",
+                heading=False,
+            ),
+        ]
+
+        lines = list(Document._lines_index(items))
+
+        self.assertIn("- REQ001: # HEADING # My Heading", lines)
+        self.assertIn("- REQ002: # Requirement Header", lines)
+        self.assertIn("- REQ003: # Requirement text", lines)
+
+    def test_read_index_converts_heading_marker(self):
+        """Verify '# HEADING #' comments are converted to heading entries."""
+        lines = """initial: 1.2.3
+outline:
+    - REQ001: # HEADING # My Heading"""
+
+        expected = {
+            "initial": "1.2.3",
+            "outline": [
+                {"REQ001": [{"header": "My Heading"}]},
+            ],
+        }
+
+        with patch("builtins.open", mock.mock_open(read_data=lines)):
+            actual = self.document._read_index("mock_path")
+
+        self.assertEqual(expected, actual)
+
+    def test_read_index_converts_heading_marker_with_whitespace(self):
+        """Verify heading markers tolerate additional whitespace."""
+        lines = """initial: 1.2.3
+outline:
+    - REQ001: #     heading      #     My Heading"""
+
+        expected = {
+            "initial": "1.2.3",
+            "outline": [
+                {"REQ001": [{"header": "My Heading"}]},
+            ],
+        }
+
+        with patch("builtins.open", mock.mock_open(read_data=lines)):
+            actual = self.document._read_index("mock_path")
+
+        self.assertEqual(expected, actual)
+
+    def test_read_index_preserves_empty_comment(self):
+        """Verify empty comments are not converted to text or heading entries."""
+        lines = """initial: 1.2.3
+outline:
+    - REQ001: #"""
+
+        expected = {
+            "initial": "1.2.3",
+            "outline": [
+                {"REQ001": None},
+            ],
+        }
+
+        with patch("builtins.open", mock.mock_open(read_data=lines)):
+            actual = self.document._read_index("mock_path")
+
+        self.assertEqual(expected, actual)
+
+
+class ReorderItem:
+    """Simple item fake for _reorder_section tests."""
+
+    def __init__(self, uid="REQ999", level=None):
+        self.uid = uid
+        self.level = level
+        self.text = ""
+        self.header = ""
+        self.normative = True
+
+
+class ReorderDocument:
+    """Simple document fake for _reorder_section tests."""
+
+    def __init__(self, existing=None):
+        self.existing = existing or {}
+        self.added = []
+
+    def find_item(self, uid):
+        if uid in self.existing:
+            return self.existing[uid]
+        raise DoorstopError(uid)
+
+    def add_item(self, level=None, reorder=False):  # pylint: disable=unused-argument
+        item = ReorderItem(
+            uid="REQ999",
+            level=level.copy() if level else None,
+        )
+        self.added.append(item)
+        return item
+
 
 @patch("doorstop.core.item.Item", MockItem)
 class TestDocumentReorder(unittest.TestCase):
@@ -1058,3 +1189,88 @@ class TestDocumentReorder(unittest.TestCase):
         actual = [item.level for item in items]
         self.assertListEqual(expected, actual)
         self.assertEqual(mock_item.method_calls, [call.delete()])
+
+    def test_reorder_section_creates_new_heading_without_children(self):
+        """Verify a new heading item can be created without child items."""
+        document = ReorderDocument()
+        ids = []
+
+        section = {
+            "NEW": [
+                {"header": "New Heading with a Header"},
+            ]
+        }
+
+        Document._reorder_section(section, Level("1"), document, ids)
+
+        self.assertEqual(1, len(document.added))
+
+        item = document.added[0]
+        self.assertTrue(item.level.heading)
+        self.assertEqual("1.0", str(item.level))
+        self.assertFalse(item.normative)
+        self.assertEqual("New Heading with a Header", item.header)
+        self.assertEqual("", item.text)
+
+    def test_reorder_section_creates_new_requirement_with_text(self):
+        """Verify a new non-heading item gets its text from the index comment."""
+        document = ReorderDocument()
+        ids = []
+
+        section = {
+            "NEW": [
+                {"text": "New requirement text"},
+            ]
+        }
+
+        Document._reorder_section(section, Level("1"), document, ids)
+
+        self.assertEqual(1, len(document.added))
+
+        item = document.added[0]
+        self.assertFalse(item.level.heading)
+
+    def test_reorder_section_existing_item_keeps_content(self):
+        """Verify existing items keep their content during manual reorder."""
+        item = ReorderItem(uid="REQ001", level=Level("1"))
+        item.header = "Existing Header"
+        item.text = "Existing Text"
+        item.normative = False
+
+        document = ReorderDocument(existing={"REQ001": item})
+        ids = []
+
+        section = {
+            "REQ001": [
+                {"heading": "Changed Header From Index"},
+            ]
+        }
+
+        Document._reorder_section(section, Level("2"), document, ids)
+
+    def test_reorder_section_sets_heading_when_children_exist(self):
+        """Verify an item with direct child elements is treated as a heading."""
+        document = ReorderDocument()
+        ids = []
+
+        section = {
+            "NEW": [
+                {"DOC-001": [{"text": "Child requirement"}]},
+            ]
+        }
+
+        Document._reorder_section(section, Level("1"), document, ids)
+
+        self.assertEqual(2, len(document.added))
+
+        parent = document.added[0]
+        child = document.added[1]
+
+        self.assertTrue(parent.level.heading)
+        self.assertEqual("1.0", str(parent.level))
+        self.assertFalse(parent.normative)
+
+        self.assertFalse(child.level.heading)
+        self.assertEqual("1.1", str(child.level))
+        self.assertTrue(child.normative)
+        self.assertEqual("Child requirement", child.text)

--- a/doorstop/core/tests/test_importer.py
+++ b/doorstop/core/tests/test_importer.py
@@ -90,7 +90,7 @@ class TestModule(unittest.TestCase):
         # Act
         importer._file_yml(path, mock_document)
         # Assert
-        self.assertEqual(6, mock_add_item.call_count)
+        self.assertEqual(7, mock_add_item.call_count)
 
     @patch("doorstop.core.importer.add_item")
     def test_file_yml_duplicates(self, mock_add_item):
@@ -100,7 +100,7 @@ class TestModule(unittest.TestCase):
         # Act
         importer._file_yml(path, mock_document)
         # Assert
-        self.assertEqual(6, mock_add_item.call_count)
+        self.assertEqual(7, mock_add_item.call_count)
 
     def test_file_yml_bad_format(self):
         """Verify YAML file import can handle bad data."""
@@ -200,6 +200,19 @@ class TestModule(unittest.TestCase):
                 False,
                 "",
                 True,
+                "",
+            ],
+            [
+                "REQ007",
+                "3.0",
+                "",
+                "",
+                "",
+                "",
+                True,
+                False,
+                "My Heading",
+                False,
                 "",
             ],
         ]

--- a/doorstop/core/tests/test_tree.py
+++ b/doorstop/core/tests/test_tree.py
@@ -17,7 +17,7 @@ import pytest
 from doorstop.common import DoorstopError, DoorstopInfo, DoorstopWarning
 from doorstop.core.builder import build
 from doorstop.core.document import Document
-from doorstop.core.tests import EMPTY, FILES, SYS, MockDocumentSkip
+from doorstop.core.tests import EMPTY, FILES, GOLDEN_MASTER_FILES, SYS, MockDocumentSkip
 from doorstop.core.tree import Tree
 
 
@@ -30,7 +30,7 @@ def reset_fixture_files():
     try:
         test_dir = os.path.dirname(__file__)
 
-        # get all git-tracked YAML-files in files/
+        # Get all git-tracked YAML files in files/
         result = subprocess.run(
             ["git", "ls-files", "files/*.yml", "files/*.yaml"],
             capture_output=True,
@@ -43,7 +43,18 @@ def reset_fixture_files():
         if result.returncode == 0 and result.stdout.strip():
             yaml_files = result.stdout.strip().split("\n")
 
-            # reset those files
+            # Exclude golden master files from reset as they are
+            # intentionally updated by tests using the golden master pattern
+            yaml_files = [
+                f
+                for f in yaml_files
+                if os.path.abspath(os.path.join(test_dir, f)) not in GOLDEN_MASTER_FILES
+            ]
+
+            if not yaml_files:
+                return
+
+            # Reset those files
             subprocess.run(
                 ["git", "checkout", "--"] + yaml_files,
                 capture_output=True,

--- a/reqs/tutorial/TUT017.yml
+++ b/reqs/tutorial/TUT017.yml
@@ -95,7 +95,11 @@ text: |
 
   $$k_{n+1} = n^2 + k_n^2 - k_{n-1}$$
 
-  Alternatively you can also use inline math like this: `$e=mc^2$` renders as $e=mc^2$.
+  #### Inline Math
+
+  You can use inline math like this `$e= mc^2$` if you only use the HTML publishing and not the LaTeX publishing.  
+
+  For the moment being, there is a bug in the LaTeX export in handling inline math. It works well in HTML export, but the LaTeX compile is likely to fail. See [\#776](https://github.com/doorstop-dev/doorstop/issues/776).
 
   ### Code blocks
 


### PR DESCRIPTION

**Description**

This PR fixes heading handling during manual reorder and addresses the long-standing issue described in #246.

## What changed

Manual reorder now preserves heading items explicitly in `index.yml`.

Existing heading items are written with a marker:

```yaml
- REQ001: # HEADING # Overview
```

When the index is read back, this marker is recognized and the item keeps its heading level, including the trailing `.0`. This also works for headings without child items, which was the root cause of #246.

The marker is parsed case-insensitively and tolerates additional whitespace, for example:

```yaml
- REQ001: # HEADING # Overview
- REQ001: # heading    # Overview
```

## Relation to #246

Issue #246 reports that heading items without child items lose their heading status during manual reorder because Doorstop previously inferred headings mainly from the index structure.

With this PR, heading information is stored explicitly in the generated `index.yml`, so a heading such as `1.1.0` remains a heading after reorder even if it has no child items.

This should close #246.

## Index comments

When generating `index.yml`, Doorstop now prefers the item `header` as the comment text if one exists. If no header is set, it falls back to the beginning of the item text.

For heading items, the comment is prefixed with `# HEADING #`.

## Documentation

The reorder documentation was updated to explain:

- how heading items are represented in `index.yml`
- how to create new heading items using `# heading #`
- that header text is preferred over item text in the generated index comments

## Compatibility

There are no breaking changes for existing requirement data.

Existing item files do not need to be changed. The new marker is only used in the temporary `index.yml` generated during manual reorder. Existing index files without the marker continue to work as before.