### PR TITLE
Fix doorstop publish hang on Markdown lists with an indented first item (#747)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.2 (unreleased)
+
+- Fixed `doorstop publish` hanging when a Markdown list's first item is indented (for example a bullet or numbered list nested under a lead-in line). ([#747](https://github.com/doorstop-dev/doorstop/issues/747))
+
 # 3.1 (2026-01-31)
 
 - Dropped support for Python 3.9 and added support for Python 3.14.

--- a/doorstop/core/publishers/base.py
+++ b/doorstop/core/publishers/base.py
@@ -42,6 +42,7 @@ class BasePublisher(metaclass=ABCMeta):
         self.list: Dict[str, Dict[str, Any]] = {}
         self.list["depth"] = {"itemize": 0, "enumerate": 0}
         self.list["indent"] = {"itemize": 0, "enumerate": 0}
+        self.list["base"] = {"itemize": 0, "enumerate": 0}
         self.list["found"] = {"itemize": False, "enumerate": False}
         # Create regexps.
         self.list["regexp"] = {
@@ -227,6 +228,16 @@ class BasePublisher(metaclass=ABCMeta):
         no_paragraph = False
         if matches:
             indent = len(line) - len(line.lstrip())
+            if not self.list["found"][list_type]:
+                # The first item establishes the base indentation of the list.
+                self.list["base"][list_type] = indent
+            # Work with indentation relative to the list's base level. Without
+            # this, a list whose first item is itself indented sets a non-zero
+            # depth while the per-level step stays zero, so the list-closing
+            # loops (which subtract the step from the depth) never terminate and
+            # `doorstop publish` hangs. Normalizing to the base level makes such
+            # lists behave exactly like lists starting at column zero. See #747.
+            indent = max(0, indent - self.list["base"][list_type])
             if not self.list["found"][list_type]:
                 block.append(self.list["start"][list_type])
                 self.list["found"][list_type] = True

--- a/doorstop/core/publishers/tests/test_publisher_latex_environments.py
+++ b/doorstop/core/publishers/tests/test_publisher_latex_environments.py
@@ -545,11 +545,14 @@ class TestPublisherModuleEnvironments(MockDataMixIn, unittest.TestCase):
     def test_missing_changing_list_indentation(self):
         """Verify that a list throws an error if indentation is changed in the middle of the list."""
         # Setup
+        # The list nests by 2 spaces, then jumps by 5, which is an inconsistent
+        # indentation step and must raise an error.
         generated_data = (
             r"text: |" + "\n"
             r"  List without newline:" + "\n"
-            r"    1. Item 1" + "\n"
-            r"        1. Item 1.1"
+            r"  1. Item 1" + "\n"
+            r"    1. Item 1.1" + "\n"
+            r"         1. Item 1.1.1"
         )
         item = MockItemAndVCS(
             "path/to/REQ-001.yml",
@@ -558,3 +561,38 @@ class TestPublisherModuleEnvironments(MockDataMixIn, unittest.TestCase):
         # Act & Assert
         with self.assertRaises(DoorstopError):
             _ = getLines(publisher.publish_lines(item, ".tex"))
+
+    def test_indented_list_does_not_hang(self):
+        """Verify that a list whose first item is indented is published, not hung.
+
+        Regression test for https://github.com/doorstop-dev/doorstop/issues/747:
+        a bullet/number list indented under a lead-in line used to make the
+        list-closing loop spin forever because the per-level indentation step was
+        never initialized.
+        """
+        # Setup
+        generated_data = (
+            r"text: |" + "\n"
+            r"  The VCU SHALL:" + "\n"
+            r"  " + "\n"
+            r"    - Execute initialization" + "\n"
+            r"    - Enter Ready-to-Ride state" + "\n"
+            r"    - Assert Ready indication"
+        )
+        item = MockItemAndVCS(
+            "path/to/REQ-001.yml",
+            _file=generated_data,
+        )
+        expected = (
+            r"\section{REQ-001}\label{REQ-001}\zlabel{REQ-001}" + "\n\n"
+            r"The VCU SHALL:\\" + "\n\n"
+            r"\begin{itemizeDeep}" + "\n"
+            r"\item Execute initialization" + "\n"
+            r"\item Enter Ready-to-Ride state" + "\n"
+            r"\item Assert Ready indication" + "\n"
+            r"\end{itemizeDeep}" + "\n\n"
+        )
+        # Act
+        result = getLines(publisher.publish_lines(item, ".tex"))
+        # Assert
+        self.assertEqual(expected, result)


### PR DESCRIPTION
## Summary

Fixes #747. `doorstop publish` hangs indefinitely (no error, no output) when a Markdown list inside an item's `text` block has its **first item indented** — for example a bullet or numbered list nested under a lead-in line:

```yaml
text: |
  The VCU SHALL:
    - Execute initialization
    - Enter Ready-to-Ride state
    - Assert Ready indication
```

A list that starts at column zero publishes fine; only an indented first item triggers the hang. This matches the report and the follow-up comment on the issue (indentation is the trigger).

## Root cause

List rendering for the HTML/LaTeX publishers lives in `Publisher.process_lists` / `Publisher._check_for_list_end` (`doorstop/core/publishers/base.py`). It tracks the current `depth` (indentation in spaces) and an `indent` **step** (spaces per nesting level), and closes levels with loops that subtract the step from the depth:

```python
while self.list["depth"][list_type] > 0:
    block.append(self.list["end"][list_type])
    self.list["depth"][list_type] -= self.list["indent"][list_type]
```

The per-level step is only initialized when a *deeper* item arrives while `depth == 0`. When the **first** item of a list is already indented, `depth` is set to that indent (`> 0`) but the step stays `0`. The closing loop then computes `depth - 0` forever → infinite loop → the publish command hangs.

(For one specific shape — `1. Item` then a deeper `1. Item 1.1` — the old code happened to raise `DoorstopError` instead of hanging, again only as a side effect of the uninitialized step, even though that input is a perfectly consistent nested list.)

## Fix

Normalize each list line's indentation relative to the list's **base** level (the indentation of its first item). An indented-from-the-start list then behaves exactly like a list that starts at column zero, so the step initializes and the closing loops terminate. Genuinely inconsistent indentation steps (e.g. nest by 2 then jump by 5) still raise `DoorstopError` as before.

The change is contained to `process_lists` plus one new tracking dict (`self.list["base"]`).

## Verification

- Reproduced the hang on `develop` (the publish thread spins in `_check_for_list_end`); confirmed it is gone after the fix for bullet and numbered lists, indented with and without a preceding blank line, for both `.html` and `.tex`.
- An indented list now produces the same balanced markup as the equivalent column-zero list (verified identical LaTeX output; nested lists open/close correctly).
- `make test` / `pytest` — the full publisher suite passes (97/97). The remaining failures in the wider suite are pre-existing on `develop` in this environment (missing optional test deps such as `xmldiff`/`webtest` and git fixtures) and are unchanged by this PR; this PR adds one new passing test.
- `black --check` and `isort --check` are clean on the changed files.

### Tests
- Added `test_indented_list_does_not_hang` — regression test for #747 (indented list publishes to the expected LaTeX instead of hanging).
- Updated `test_missing_changing_list_indentation` to use a genuinely inconsistent indentation step, so it keeps verifying the error path (the previous input was a consistent nested list that only errored because of the bug being fixed here).

---