### PR TITLE
Fix infinite loop when publishing an indented markdown list

### DIFF
--- a/doorstop/core/publishers/base.py
+++ b/doorstop/core/publishers/base.py
@@ -231,6 +231,10 @@ class BasePublisher(metaclass=ABCMeta):
                 block.append(self.list["start"][list_type])
                 self.list["found"][list_type] = True
                 self.list["depth"][list_type] = indent
+                # A list that already starts indented defines its own step.
+                # Without this the step stays 0 and the loops that unwind the
+                # depth below never terminate.
+                self.list["indent"][list_type] = indent
             elif self.list["depth"][list_type] < indent:
                 block.append(self.list["start"][list_type])
                 if self.list["depth"][list_type] == 0:

--- a/doorstop/core/publishers/tests/test_publisher_html.py
+++ b/doorstop/core/publishers/tests/test_publisher_html.py
@@ -14,6 +14,7 @@ from unittest.mock import ANY, MagicMock, Mock, call, patch
 
 from doorstop.core import publisher
 from doorstop.core.document import Document
+from doorstop.core.publishers.html import HtmlPublisher
 from doorstop.core.template import HTMLTEMPLATE
 from doorstop.core.tests import (
     EMPTY,
@@ -380,3 +381,27 @@ class TestTableOfContents(unittest.TestCase):
         html_publisher = publisher.check(".html", self.document)
         toc = html_publisher.table_of_contents(linkify=True, obj=self.document)
         self.assertEqual(expected, toc)
+
+
+class TestProcessLists(unittest.TestCase):
+    """Unit tests for list processing in the HTML publisher."""
+
+    def setUp(self):
+        self.publisher = HtmlPublisher(Mock(), ".html")
+
+    def test_list_starting_indented_terminates(self):
+        """Verify a list whose first item is indented does not loop forever."""
+        self.publisher.process_lists("  - item one", "  - item two")
+
+        # Unwinding to a smaller indentation must terminate.
+        _, block, line = self.publisher.process_lists("- outer", "")
+
+        self.assertIn("</ul>", block)
+        self.assertEqual("</ul>", line)
+
+    def test_list_starting_indented_terminates_at_end_of_list(self):
+        """Verify an indented list is closed when the list ends."""
+        _, _, line = self.publisher.process_lists("  - only item", "")
+
+        self.assertEqual("</ul>", line)
+        self.assertFalse(self.publisher.list["found"]["itemize"])


### PR DESCRIPTION
Closes #739

Publishing a document whose `text:` block starts a bullet list at a non-zero indentation hangs forever and eats memory until the process is killed (also reported in #747).

When the first list line is already indented, `process_lists()` records that indentation as the list depth but leaves the per-level indent step at its initial `0`. Both loops that unwind the depth subtract that step, so they never make progress. Letting the list's opening indentation also define its indent step makes the unwinding terminate.

Without the fix the added tests hang (timeout); with it they pass, and the rest of the publisher suite is unchanged.
