### PR TITLE
Report links to inactive items as inactive, not unknown

### DIFF
--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -853,10 +853,11 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
             for item in items_at_level:
                 yield level, item
 
-    def find_item(self, value, _kind=""):
+    def find_item(self, value, _kind="", include_inactive=False):
         """Return an item by its UID.
 
         :param value: item or UID
+        :param include_inactive: also return items that are inactive
 
         :raises: :class:`~doorstop.common.DoorstopError` if the item
             cannot be found
@@ -867,7 +868,7 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
         uid = UID(value)
         for item in self:
             if item.uid == uid:
-                if item.active:
+                if item.active or include_inactive:
                     return item
                 else:
                     log.trace("item is inactive: {}".format(item))  # type: ignore

--- a/doorstop/core/tests/test_item_validator.py
+++ b/doorstop/core/tests/test_item_validator.py
@@ -166,6 +166,27 @@ class TestItemValidator(unittest.TestCase):
         self.assertTrue(self.item_validator.validate(self.item))
 
     @patch("doorstop.settings.STAMP_NEW_LINKS", False)
+    def test_validate_link_to_inactive_is_found(self):
+        """Verify an inactive parent is reported as inactive, not unknown."""
+        mock_item = Mock()
+        mock_item.active = False
+
+        def find_item(uid, _kind="", include_inactive=False):
+            """Behave like Tree.find_item, which hides inactive items."""
+            if not include_inactive:
+                raise DoorstopError("no item with UID: {}".format(uid))
+            return mock_item
+
+        mock_tree = MagicMock()
+        mock_tree.find_item = find_item
+        self.item.links = ["a"]
+        self.item.tree = mock_tree
+        self.item_validator.disable_get_issues_document()
+        with ListLogHandler(core.validators.item_validator.log) as handler:
+            self.assertTrue(self.item_validator.validate(self.item))
+            self.assertNotIn("linked to unknown item: a", handler.records)
+
+    @patch("doorstop.settings.STAMP_NEW_LINKS", False)
     def test_validate_link_to_nonnormative(self):
         """Verify a link to an non-normative item can be checked."""
         mock_item = Mock()
@@ -219,7 +240,7 @@ class TestItemValidator(unittest.TestCase):
 
         mock_tree = Mock()
         mock_tree.__iter__ = mock_iter
-        mock_tree.find_item = lambda uid: Mock(uid="fake1")
+        mock_tree.find_item = lambda uid, **kwargs: Mock(uid="fake1")
 
         self.item.tree = mock_tree
 
@@ -285,7 +306,7 @@ class TestItemValidator(unittest.TestCase):
 
         mock_tree = Mock()
         mock_tree.__iter__ = mock_iter
-        mock_tree.find_item = lambda uid: Mock(uid="fake1")
+        mock_tree.find_item = lambda uid, **kwargs: Mock(uid="fake1")
         self.item.tree = mock_tree
 
         self.assertTrue(self.item_validator.validate(self.item))
@@ -328,7 +349,7 @@ class TestItemValidator(unittest.TestCase):
 
         mock_tree = Mock()
         mock_tree.__iter__ = mock_iter([root_doc, child_doc_a, child_doc_b])
-        mock_tree.find_item = lambda uid: next(
+        mock_tree.find_item = lambda uid, **kwargs: next(
             filter(lambda item: item.uid == uid, all_items), None
         )
 

--- a/doorstop/core/tree.py
+++ b/doorstop/core/tree.py
@@ -415,10 +415,11 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
 
         raise DoorstopError(Prefix.UNKNOWN_MESSAGE.format(prefix))
 
-    def find_item(self, value, _kind=""):
+    def find_item(self, value, _kind="", include_inactive=False):
         """Get an item by its UID.
 
         :param value: item or UID
+        :param include_inactive: also return items that are inactive
 
         :raises: :class:`~doorstop.common.DoorstopError` if the item
             cannot be found
@@ -433,7 +434,7 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
             item = self._item_cache[uid]
             if item:
                 log.trace("found cached item: {}".format(item))  # type: ignore
-                if item.active:
+                if item.active or include_inactive:
                     return item
                 else:
                     log.trace("item is inactive: {}".format(item))  # type: ignore
@@ -442,7 +443,9 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
         except KeyError:
             for document in self:
                 try:
-                    item = document.find_item(uid, _kind=_kind)
+                    item = document.find_item(
+                        uid, _kind=_kind, include_inactive=include_inactive
+                    )
                 except DoorstopError:
                     pass  # item not found in that document
                 else:
@@ -450,7 +453,7 @@ class Tree(BaseValidatable):  # pylint: disable=R0902
                     if settings.CACHE_ITEMS:
                         self._item_cache[uid] = item
                         log.trace("cached item: {}".format(item))  # type: ignore
-                    if item.active:
+                    if item.active or include_inactive:
                         return item
                     else:
                         log.trace("item is inactive: {}".format(item))  # type: ignore

--- a/doorstop/core/validators/item_validator.py
+++ b/doorstop/core/validators/item_validator.py
@@ -159,7 +159,7 @@ class ItemValidator:
         identifiers = set()
         for uid in item.links:
             try:
-                parent = tree.find_item(uid)
+                parent = tree.find_item(uid, include_inactive=True)
             except DoorstopError:
                 identifiers.add(uid)  # keep the invalid UID
                 msg = "linked to unknown item: {}".format(uid)


### PR DESCRIPTION
Closes #726.

`Tree.find_item()` and `Document.find_item()` skip inactive items, so `ItemValidator._get_issues_tree()` never saw an inactive parent and its `linked to inactive item` branch was unreachable — the lookup raised instead, and the link was reported as `linked to unknown item` (a `DoorstopError`) rather than the intended `DoorstopInfo`.

Both lookups gain an `include_inactive` flag defaulting to `False`, so every other caller is unchanged, and the validator opts in. The new test fails on `develop` with the unknown-item error and passes with the fix.
