### PR TITLE
Do not escape dollar signs delimiting inline math in LaTeX export

### DIFF
--- a/doorstop/core/publishers/_latex_functions.py
+++ b/doorstop/core/publishers/_latex_functions.py
@@ -85,8 +85,7 @@ def _latex_convert_with_inline_math(line):
     if len(parts) < 3 or len(parts) % 2 == 0:
         return _latex_convert(line)
     return "$".join(
-        part if index % 2 else _latex_convert(part)
-        for index, part in enumerate(parts)
+        part if index % 2 else _latex_convert(part) for index, part in enumerate(parts)
     )
 
 

--- a/doorstop/core/publishers/_latex_functions.py
+++ b/doorstop/core/publishers/_latex_functions.py
@@ -76,6 +76,20 @@ def _latex_convert(line):
     return line
 
 
+def _latex_convert_with_inline_math(line):
+    """Convert a line to LaTeX, leaving inline math ($...$) untouched."""
+    # Split on unescaped dollar signs so that literal '\$' is left alone.
+    parts = re.split(r"(?<!\\)\$", line)
+    # A complete inline math environment yields an odd number of parts, of
+    # which every second one is math. Anything else has no math to protect.
+    if len(parts) < 3 or len(parts) % 2 == 0:
+        return _latex_convert(line)
+    return "$".join(
+        part if index % 2 else _latex_convert(part)
+        for index, part in enumerate(parts)
+    )
+
+
 def _typeset_latex_image(image_match, line, block):
     """Typeset images."""
     image_title, image_path = image_match[0]

--- a/doorstop/core/publishers/latex.py
+++ b/doorstop/core/publishers/latex.py
@@ -14,6 +14,7 @@ from doorstop.core.publishers._latex_functions import (
     _check_for_new_table,
     _fix_table_line,
     _latex_convert,
+    _latex_convert_with_inline_math,
     _typeset_latex_image,
 )
 from doorstop.core.publishers.base import (
@@ -437,7 +438,7 @@ class LaTeXPublisher(BasePublisher):
                         "Cannot handle multiple math environments on one row."
                     )
             else:
-                line = _latex_convert(line)
+                line = _latex_convert_with_inline_math(line)
             # Skip all other changes if in MATH!
             if math_found:
                 line = line + "\\\\"

--- a/doorstop/core/publishers/tests/test_publisher_latex.py
+++ b/doorstop/core/publishers/tests/test_publisher_latex.py
@@ -485,3 +485,30 @@ class TestPublisherModule(MockDataMixIn, unittest.TestCase):
         result = getLines(publisher.publish_lines(item, ".tex"))
         # Assert
         self.assertEqual(expected, result)
+
+    def test_inline_math_is_not_escaped(self):
+        """Verify that dollar signs delimiting inline math are not escaped."""
+        generated_data = (
+            r"active: true" + "\n"
+            r"derived: false" + "\n"
+            r"header: ''" + "\n"
+            r"level: 1.1" + "\n"
+            r"normative: false" + "\n"
+            r"reviewed:" + "\n"
+            r"text: |" + "\n"
+            r"  Inline math like $e=mc^2$ is rendered." + "\n"
+            r"  An unpaired $ sign stays escaped."
+        )
+        item = MockItemAndVCS(
+            "path/to/REQ-001.yml",
+            _file=generated_data,
+        )
+        expected = (
+            r"\subsection{REQ-001}\label{REQ-001}\zlabel{REQ-001}" + "\n\n"
+            r"Inline math like $e=mc^2$ is rendered." + "\n"
+            r"An unpaired \$ sign stays escaped." + "\n\n"
+        )
+        # Act
+        result = getLines(publisher.publish_lines(item, ".tex"))
+        # Assert
+        self.assertEqual(expected, result)


### PR DESCRIPTION
Closes #776

Inline math written as `$e=mc^2$` is exported as `\$e=mc^2\$`, which breaks the LaTeX compile. `_latex_convert()` escapes every dollar sign, and the publisher only bypasses it for display math (`$$...$$`).

`_latex_convert_with_inline_math()` splits a line on unescaped dollar signs and converts only the non-math segments, so a complete inline math environment is left alone. Lines with an unpaired `$`, or an already-escaped `\$`, keep the previous escaping behaviour.

The added regression test in `test_publisher_latex.py` fails without the fix and passes with it; the rest of the publisher suite is unchanged.
