### PR TITLE
Save the document extensions configuration

### DIFF
--- a/doorstop/core/document.py
+++ b/doorstop/core/document.py
@@ -266,6 +266,9 @@ class Document(BaseValidatable, BaseFileObject):  # pylint: disable=R0902
             attributes["reviewed"] = self._extended_reviewed
         if attributes:
             data["attributes"] = attributes
+        # Save the extensions
+        if self.extensions:
+            data["extensions"] = self.extensions
         # Dump the data to YAML
         text = self._dump(data)
         # Save the YAML to file

--- a/doorstop/core/tests/test_document.py
+++ b/doorstop/core/tests/test_document.py
@@ -252,6 +252,18 @@ class TestDocument(unittest.TestCase):
         self.assertNotIn("attributes:", self.document._file)
         self.assertNotIn("  reviewed:", self.document._file)
 
+    def test_save_extensions(self):
+        """Verify saving of the extensions configuration."""
+        self.document.extensions = {"item_validator": "validator.py"}
+        self.document.save()
+        self.assertIn("extensions:", self.document._file)
+        self.assertIn("  item_validator: validator.py", self.document._file)
+
+    def test_no_save_empty_extensions(self):
+        """Verify not saving of an empty extensions configuration."""
+        self.document.save()
+        self.assertNotIn("extensions:", self.document._file)
+
     def test_save_custom_defaults(self):
         """Verify saving of custom default attributes."""
         self.document._attribute_defaults = {"key": "value"}


### PR DESCRIPTION
Closes #681

`Document.load()` reads the `extensions` key from the document config, but `Document.save()` only wrote `settings` and `attributes` — so a document with an `extensions` section (e.g. a custom `item_validator`) silently lost it the first time doorstop rewrote the config. `save()` now emits `extensions` when the document has any, mirroring how `attributes` is written only when non-empty.

Regression test in `doorstop/core/tests/test_document.py` fails without the change and passes with it.
