### PR TITLE
Do not warn about missing text on headings that have a header

### DIFF
--- a/doorstop/core/tests/test_all.py
+++ b/doorstop/core/tests/test_all.py
@@ -250,7 +250,7 @@ class TestDocument(unittest.TestCase):
         issues = self.document.issues
         for issue in self.document.issues:
             logging.info(repr(issue))
-        self.assertEqual(15, len(issues))
+        self.assertEqual(14, len(issues))
 
     @patch("doorstop.settings.REORDER", False)
     @patch("doorstop.settings.REVIEW_NEW_ITEMS", False)
@@ -406,7 +406,7 @@ class TestTree(unittest.TestCase):
         issues = self.tree.issues
         for issue in self.tree.issues:
             logging.info(repr(issue))
-        self.assertEqual(17, len(issues))
+        self.assertEqual(16, len(issues))
 
     @patch("doorstop.settings.REORDER", False)
     @patch("doorstop.settings.REVIEW_NEW_ITEMS", False)

--- a/doorstop/core/tests/test_item_validator.py
+++ b/doorstop/core/tests/test_item_validator.py
@@ -11,7 +11,7 @@ from doorstop import core
 from doorstop.common import DoorstopError
 from doorstop.core.tests import MockItem, MockItemValidator, MockSimpleDocument
 from doorstop.core.tests.helpers import ListLogHandler
-from doorstop.core.types import Stamp
+from doorstop.core.types import Level, Stamp
 
 
 class TestItemValidator(unittest.TestCase):
@@ -197,6 +197,26 @@ class TestItemValidator(unittest.TestCase):
         self.item.tree = mock_tree
         self.item_validator.disable_get_issues_document()
         self.assertTrue(self.item_validator.validate(self.item))
+
+    def test_validate_heading_with_header(self):
+        """Verify a heading described only by its header is not warned about."""
+        self.item.level = Level("1.0")
+        self.item.normative = False
+        self.item.header = "Introduction"
+        self.item.text = ""
+        with ListLogHandler(core.validators.item_validator.log) as handler:
+            self.assertTrue(self.item_validator.validate(self.item))
+            self.assertNotIn("no text", handler.records)
+
+    def test_validate_heading_without_text_or_header(self):
+        """Verify a heading with neither text nor header is warned about."""
+        self.item.level = Level("1.0")
+        self.item.normative = False
+        self.item.header = ""
+        self.item.text = ""
+        with ListLogHandler(core.validators.item_validator.log) as handler:
+            self.assertTrue(self.item_validator.validate(self.item))
+            self.assertIn("no text nor header", handler.records)
 
     def test_validate_document(self):
         """Verify an item can be checked against a document."""

--- a/doorstop/core/validators/item_validator.py
+++ b/doorstop/core/validators/item_validator.py
@@ -71,7 +71,11 @@ class ItemValidator:
             item.auto = False
 
         # Check text
-        if not item.text:
+        if item.level.heading:
+            # A heading is described by its header, its text, or both.
+            if not item.text and not item.header:
+                yield DoorstopWarning("no text nor header")
+        elif not item.text:
             yield DoorstopWarning("no text")
 
         # Check external refs and references


### PR DESCRIPTION
Closes #706

Heading items (level ending in `.0`, non-normative) are often described by `header` alone with `text` left empty, but the validator checked only `text`, so every such heading emitted a `no text` warning. Headings are now accepted when either `text` or `header` is set, and warn `no text nor header` only when both are empty; non-heading items are unchanged. This is the shape @opt12 proposed on the issue.

The `REQ007` fixture is exactly this case, so the two issue-count expectations in `test_all.py` drop by one.
