### PR TITLE
Add doorstop-vscode to examples list

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -16,3 +16,4 @@ Running `doorstop` in Docker: [tlwt/doorstop-docker](https://github.com/tlwt/doo
 - **[doorframe](https://doorframe.io/)**: This is (closed source) GitHub App that uses Doorstop as backend.
 - **[sevendays/doorhole](https://github.com/sevendays/doorhole)**: This is standalone GUI for Doorstop.
 - **[ownbee/doorstop-edit](https://github.com/ownbee/doorstop-edit)**: Cross-platform Doorstop GUI editor.
+- **[doorstop-vscode](https://github.com/simonwalbrun-lab/doorstop-vscode)**: This is a VS Code Extension for Doorstop.


### PR DESCRIPTION
Added doorstop-vscode entry to examples list.

Marketplace:[https://marketplace.visualstudio.com/items?itemName=SimonWalbrun.doorstop](https://marketplace.visualstudio.com/items?itemName=SimonWalbrun.doorstop)
Source:[https://github.com/simonwalbrun-lab/doorstop-vscode](https://github.com/simonwalbrun-lab/doorstop-vscode)

It adds a requirements explorer, Doorstop's validation in the Problems panel with quick fixes, go-to-definition and call hierarchy across links, hover previews, link autocompletion and a visual canvas. All changes go through Doorstop's own Python API via a small local server, nothing is reimplemented.

If you find it useful, I'd be happy to see it listed among the third-party projects. Feedback is always welcome.